### PR TITLE
Feat/workspaces configuration

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -30,7 +30,13 @@
           "path": "$DOCUMENT/.worklog"
         },
         {
+          "path": "$HOME/.worklog"
+        },
+        {
           "path": "$DOCUMENT/**/*"
+        },
+        {
+          "path": "$HOME/**/*"
         }
       ]
     },
@@ -41,7 +47,13 @@
           "path": "$DOCUMENT/.worklog"
         },
         {
+          "path": "$HOME/.worklog"
+        },
+        {
           "path": "$DOCUMENT/**/*"
+        },
+        {
+          "path": "$HOME/**/*"
         }
       ]
     }

--- a/src/lib/db/connection.ts
+++ b/src/lib/db/connection.ts
@@ -3,9 +3,16 @@ import { mkdir, exists } from '@tauri-apps/plugin-fs';
 import { CREATE_TABLES } from './schema';
 
 let _db: Database | null = null;
+let _dbWorkspacePath: string | null = null;
 
 export async function getDb(workspacePath: string): Promise<Database> {
-    if (_db) return _db;
+    if (_db && _dbWorkspacePath === workspacePath) return _db;
+
+    if (_db && _dbWorkspacePath !== workspacePath) {
+        await _db.close();
+        _db = null;
+        _dbWorkspacePath = null;
+    }
 
     // ── Ensure .worklog/ directory exists ──────────────
     const dirPath = `${workspacePath}/.worklog`;
@@ -16,6 +23,7 @@ export async function getDb(workspacePath: string): Promise<Database> {
 
     // ── Open or create the SQLite database ─────────────
     _db = await Database.load(`sqlite:${workspacePath}/.worklog/worklog.db`);
+    _dbWorkspacePath = workspacePath;
     await _db.execute(CREATE_TABLES);
     return _db;
 }
@@ -24,5 +32,6 @@ export async function closeDb(): Promise<void> {
     if (_db) {
         await _db.close();
         _db = null;
+        _dbWorkspacePath = null;
     }
 }


### PR DESCRIPTION
This pull request updates file access permissions and improves database connection management to better support multiple workspaces. The main changes expand the file access patterns in the Tauri capabilities configuration and ensure that the database connection is properly managed when switching between workspaces.

**File access permissions:**

* Expanded the allowed file paths in `src-tauri/capabilities/default.json` to include both `$HOME/.worklog` and all files under `$HOME/**/*`, in addition to the existing `$DOCUMENT` paths. This allows the application to access worklog files and directories in both the user's home and document directories. [[1]](diffhunk://#diff-8fe2bbfebcddedcaa718510825d2a4bd04f59d2826a6848ea55fa086c5bb4213R32-R39) [[2]](diffhunk://#diff-8fe2bbfebcddedcaa718510825d2a4bd04f59d2826a6848ea55fa086c5bb4213R49-R56)

**Database connection management:**

* Updated `getDb` in `src/lib/db/connection.ts` to track the current workspace path and close the existing database connection when switching to a different workspace, preventing cross-workspace conflicts.
* Set the workspace path when opening a new database connection and reset it when closing the database to maintain correct state. [[1]](diffhunk://#diff-1bcf173db185ad2ad3b82285c041f01a4a97262cd3f341f2272ab283610c38d6R26) [[2]](diffhunk://#diff-1bcf173db185ad2ad3b82285c041f01a4a97262cd3f341f2272ab283610c38d6R35)