### PR TITLE
feat: add context menus with common actions to workspace boards and k…

### DIFF
--- a/src/lib/components/app/kanban/kanban-ticket-card.svelte
+++ b/src/lib/components/app/kanban/kanban-ticket-card.svelte
@@ -4,6 +4,9 @@
         Tag,
         OverflowMenu,
         OverflowMenuItem,
+        ContextMenu,
+        ContextMenuOption,
+        ContextMenuDivider,
     } from "carbon-components-svelte";
     import {
         Calendar,
@@ -18,6 +21,9 @@
         ChartLineSmooth,
         Lightning,
         Explore,
+        CopyFile,
+        Edit,
+        TrashCan,
     } from "carbon-icons-svelte";
     import {
         type Ticket,
@@ -58,9 +64,25 @@
     const TypeIcon = $derived(typeIconMap[ticket.ticket_type]);
     const priorityConfig = $derived(TICKET_PRIORITY_CONFIG[ticket.priority]);
     const PriorityIcon = $derived(priorityIconMap[ticket.priority]);
+
+    let cardElement = $state<HTMLElement>();
+
+    function copyToClipboard(text: string) {
+        if (navigator.clipboard) {
+            void navigator.clipboard.writeText(text);
+        }
+    }
 </script>
 
-<article class="ticket-card">
+<article class="ticket-card" bind:this={cardElement}>
+    <ContextMenu target={cardElement ? [cardElement] : []}>
+        <ContextMenuOption labelText="Copy Ticket ID" icon={CopyFile} on:click={() => copyToClipboard(ticket.id)} />
+        <ContextMenuOption labelText="Copy Title" icon={CopyFile} on:click={() => copyToClipboard(ticket.title)} />
+        <ContextMenuDivider />
+        <ContextMenuOption labelText="Edit Ticket" icon={Edit} on:click={() => onEdit?.(ticket)} />
+        <ContextMenuOption kind="danger" labelText="Delete Ticket" icon={TrashCan} on:click={() => onDelete?.(ticket.id)} />
+    </ContextMenu>
+
     <!-- Drag handle -->
     <div class="drag-handle" aria-hidden="true">
         <Draggable size={16} />

--- a/src/lib/components/app/layout/workspace/workspace-sidebar.svelte
+++ b/src/lib/components/app/layout/workspace/workspace-sidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Settings } from "carbon-icons-svelte";
+    import { Settings, CopyFile, Launch, TrashCan } from "carbon-icons-svelte";
 
     import {
         Button,
@@ -13,6 +13,9 @@
         TextArea,
         TextInput,
         TileGroup,
+        ContextMenu,
+        ContextMenuOption,
+        ContextMenuDivider,
     } from "carbon-components-svelte";
 
     import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
@@ -133,6 +136,33 @@
         creatingBoard = false;
     });
 
+    let boardRefs = $state<Record<string, HTMLElement | null>>({});
+
+    function captureRef(node: HTMLElement, boardId: string) {
+        boardRefs[boardId] = node.closest(".bx--tile") as HTMLElement;
+        return {
+            destroy() {
+                if (boardRefs[boardId] === node.closest(".bx--tile")) {
+                    delete boardRefs[boardId];
+                }
+            },
+        };
+    }
+
+    function copyToClipboard(text: string) {
+        if (navigator.clipboard) {
+            void navigator.clipboard.writeText(text);
+        }
+    }
+
+    async function deleteBoard(id: string) {
+        try {
+            await boardsApi.remove(id);
+        } catch (error) {
+            console.error("Failed to delete board:", error);
+        }
+    }
+
     // Listen for create-board events from the command palette / shortcuts
     $effect(() => {
         const handler = () => openCreateBoardModal();
@@ -172,13 +202,40 @@
                         value={board.id}
                         onclick={() => handleBoardClick(board.id)}
                     >
-                        <span class="workspace-board-name">{board.name}</span>
+                        <span
+                            class="workspace-board-name"
+                            use:captureRef={board.id}>{board.name}</span
+                        >
                         {#if board.description}
                             <span class="workspace-board-description">
                                 {board.description}
                             </span>
                         {/if}
                     </RadioTile>
+
+                    <ContextMenu
+                        target={boardRefs[board.id]
+                            ? [boardRefs[board.id]]
+                            : []}
+                    >
+                        <ContextMenuOption
+                            labelText="Open Board"
+                            icon={Launch}
+                            on:click={() => openBoard(board.id)}
+                        />
+                        <ContextMenuOption
+                            labelText="Copy Board ID"
+                            icon={CopyFile}
+                            on:click={() => copyToClipboard(board.id)}
+                        />
+                        <ContextMenuDivider />
+                        <ContextMenuOption
+                            kind="danger"
+                            labelText="Delete Board"
+                            icon={TrashCan}
+                            on:click={() => deleteBoard(board.id)}
+                        />
+                    </ContextMenu>
                 {/each}
             </TileGroup>
         {/if}


### PR DESCRIPTION
This pull request introduces several user interface enhancements to the Kanban board and workspace sidebar components, focusing on improving usability and consistency. The main changes include replacing select dropdowns with a unified `Dropdown` component, adding context menus for ticket and board actions, and refactoring code to support these new features.

**Kanban Board Improvements:**

* Replaced the `Select` components for "Priority" and "Type" fields in the ticket creation form with the `Dropdown` component, providing a more consistent and modern user experience. (`kanban-board.svelte`) [[1]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980R11) [[2]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980L384-R405)
* Minor formatting and cleanup in the toolbar and event handler code for better readability. (`kanban-board.svelte`) [[1]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980L283-R285) [[2]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980L299-R302)

**Kanban Ticket Card Enhancements:**

* Added a context menu to each ticket card, allowing users to copy the ticket ID or title, edit, or delete the ticket directly from the card. This includes new icon imports and a utility function for copying to the clipboard. (`kanban-ticket-card.svelte`) [[1]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacR7-R9) [[2]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacR24-R26) [[3]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacR67-R85)
* Adjusted styling for the drag handle to improve the card's UI. (`kanban-ticket-card.svelte`)

**Workspace Sidebar Upgrades:**

* Introduced a context menu for each board in the sidebar, enabling actions such as opening the board, copying its ID, or deleting it. This includes new icon and component imports, a ref capturing system for context menu targeting, and a board deletion helper. (`workspace-sidebar.svelte`) [[1]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0L2-R2) [[2]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R16-R18) [[3]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R139-R165) [[4]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0L175-R238)

These changes collectively improve the application's interactivity and streamline common actions for users.