### PR TITLE
feat: add confirmation modals for board and ticket deletion workflows

### DIFF
--- a/src/lib/components/app/kanban/kanban-board.svelte
+++ b/src/lib/components/app/kanban/kanban-board.svelte
@@ -252,12 +252,24 @@
         }
     }
 
-    async function deleteTicket(id: string) {
+    let deleteTicketId = $state<string | null>(null);
+    let deleteTicketModalOpen = $state(false);
+
+    function promptDeleteTicket(id: string) {
+        deleteTicketId = id;
+        deleteTicketModalOpen = true;
+    }
+
+    async function confirmDeleteTicket() {
+        if (!deleteTicketId) return;
         try {
             actionError = null;
-            await ticketsHook.remove(id);
+            await ticketsHook.remove(deleteTicketId);
         } catch (error) {
             actionError = String(error);
+        } finally {
+            deleteTicketModalOpen = false;
+            deleteTicketId = null;
         }
     }
 
@@ -354,7 +366,7 @@
                 onfinalize={handlers.finalize}
                 onAddTicket={openAddModal}
                 onEditTicket={openEditModal}
-                onDeleteTicket={deleteTicket}
+                onDeleteTicket={promptDeleteTicket}
             />
         {/each}
     </div>
@@ -422,6 +434,22 @@
             bind:selectedIds={form.tags}
         />
     </div>
+</Modal>
+
+<Modal
+    danger
+    bind:open={deleteTicketModalOpen}
+    modalHeading="Delete Ticket"
+    primaryButtonText="Delete"
+    size="xs"
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={() => (deleteTicketModalOpen = false)}
+    on:click:button--primary={confirmDeleteTicket}
+>
+    <p>
+        Are you sure you want to delete this ticket? This action cannot be
+        undone.
+    </p>
 </Modal>
 
 <style>

--- a/src/lib/components/app/layout/workspace/workspace-sidebar.svelte
+++ b/src/lib/components/app/layout/workspace/workspace-sidebar.svelte
@@ -16,6 +16,7 @@
         ContextMenu,
         ContextMenuOption,
         ContextMenuDivider,
+        Modal,
     } from "carbon-components-svelte";
 
     import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
@@ -155,11 +156,23 @@
         }
     }
 
-    async function deleteBoard(id: string) {
+    let deleteBoardId = $state<string | null>(null);
+    let deleteModalOpen = $state(false);
+
+    function promptDeleteBoard(id: string) {
+        deleteBoardId = id;
+        deleteModalOpen = true;
+    }
+
+    async function confirmDeleteBoard() {
+        if (!deleteBoardId) return;
         try {
-            await boardsApi.remove(id);
+            await boardsApi.remove(deleteBoardId);
         } catch (error) {
             console.error("Failed to delete board:", error);
+        } finally {
+            deleteModalOpen = false;
+            deleteBoardId = null;
         }
     }
 
@@ -233,7 +246,7 @@
                             kind="danger"
                             labelText="Delete Board"
                             icon={TrashCan}
-                            on:click={() => deleteBoard(board.id)}
+                            on:click={() => promptDeleteBoard(board.id)}
                         />
                     </ContextMenu>
                 {/each}
@@ -295,6 +308,22 @@
         </Button>
     </ModalFooter>
 </ComposedModal>
+
+<Modal
+    danger
+    size="xs"
+    bind:open={deleteModalOpen}
+    modalHeading="Delete board"
+    primaryButtonText="Delete"
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={() => (deleteModalOpen = false)}
+    on:click:button--primary={confirmDeleteBoard}
+>
+    <p>
+        Are you sure you want to delete this board? This action cannot be
+        undone.
+    </p>
+</Modal>
 
 <style>
     :global(.workspace-sidebar.bx--side-nav) {


### PR DESCRIPTION
This pull request improves the user experience and safety of delete actions for both tickets and boards by introducing confirmation modals before deletion. Instead of immediately deleting items, users are now prompted to confirm their intent, reducing the risk of accidental deletions. The changes also refactor the delete logic to support this new flow.

**Enhanced Delete Confirmation Flow:**

* Added confirmation modals for deleting tickets and boards, requiring users to confirm before deletion. [[1]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980R439-R454) [[2]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R312-R327)
* Refactored delete functions for tickets and boards to use state variables for tracking the item to be deleted and modal visibility, separating the prompt and confirmation steps. [[1]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980L255-R272) [[2]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0L158-R175)

**UI Integration Updates:**

* Updated event handlers in `kanban-board.svelte` and `workspace-sidebar.svelte` to trigger the new confirmation prompt instead of deleting immediately. [[1]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980L357-R369) [[2]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0L236-R249)
* Imported the `Modal` component where necessary to support the new confirmation dialogs.