### PR TITLE
Implement grouped command palette with category, icon support, and dynamic actions

### DIFF
--- a/src/lib/components/app/layout/command-palette/command-palette.svelte
+++ b/src/lib/components/app/layout/command-palette/command-palette.svelte
@@ -24,6 +24,27 @@
             : palette.actions,
     );
 
+    // ── Grouped by category ────────────────────────────────────────────────
+    // Preserves insertion order within each group. Flat index tracks global ↑/↓.
+    interface GroupEntry {
+        category: string;
+        actions: { action: CommandAction; flatIndex: number }[];
+    }
+
+    const grouped = $derived.by(() => {
+        const map = new Map<string, { action: CommandAction; flatIndex: number }[]>();
+        filtered.forEach((action, i) => {
+            const cat = action.category ?? "Commands";
+            if (!map.has(cat)) map.set(cat, []);
+            map.get(cat)!.push({ action, flatIndex: i });
+        });
+        const result: GroupEntry[] = [];
+        for (const [category, actions] of map.entries()) {
+            result.push({ category, actions });
+        }
+        return result;
+    });
+
     // ── Keyboard navigation ────────────────────────────────────────────────
     function handleKeydown(e: KeyboardEvent) {
         if (!palette.isOpen) return;
@@ -77,7 +98,6 @@
 
     $effect(() => {
         if (palette.isOpen && inputRef) {
-            // Slight delay to allow the DOM to render
             requestAnimationFrame(() => {
                 inputRef?.focus();
             });
@@ -124,49 +144,62 @@
                 <kbd class="palette-esc-badge">ESC</kbd>
             </div>
 
-            <!-- Results list -->
+            <!-- Results list (grouped) -->
             <div class="palette-results" role="listbox">
                 {#if filtered.length === 0}
                     <div class="palette-empty">
                         <span>No commands found</span>
                     </div>
                 {:else}
-                    {#each filtered as action, i (action.id)}
-                        <!-- svelte-ignore a11y_click_events_have_key_events -->
-                        <div
-                            id="palette-item-{i}"
-                            class="palette-item"
-                            class:palette-item--selected={i ===
-                                palette.selectedIndex}
-                            role="option"
-                            tabindex="-1"
-                            aria-selected={i === palette.selectedIndex}
-                            onmouseenter={() => palette.setSelectedIndex(i)}
-                            onclick={() => palette.runAction(action)}
-                        >
-                            <div class="palette-item-left">
-                                <ArrowRight
-                                    size={16}
-                                    class="palette-item-icon"
-                                />
-                                <div class="palette-item-text">
-                                    <span class="palette-item-label"
-                                        >{action.label}</span
-                                    >
-                                    {#if action.subtitle}
-                                        <span class="palette-item-subtitle"
-                                            >{action.subtitle}</span
-                                        >
+                    {#each grouped as group}
+                        <div class="palette-group">
+                            <div class="palette-group-header">{group.category}</div>
+                            {#each group.actions as { action, flatIndex } (action.id)}
+                                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                                <div
+                                    id="palette-item-{flatIndex}"
+                                    class="palette-item"
+                                    class:palette-item--selected={flatIndex ===
+                                        palette.selectedIndex}
+                                    role="option"
+                                    tabindex="-1"
+                                    aria-selected={flatIndex === palette.selectedIndex}
+                                    onmouseenter={() => palette.setSelectedIndex(flatIndex)}
+                                    onclick={() => palette.runAction(action)}
+                                >
+                                    <div class="palette-item-left">
+                                        {#if action.icon}
+                                            {@const Icon = action.icon}
+                                            <Icon
+                                                size={16}
+                                                class="palette-item-icon"
+                                            />
+                                        {:else}
+                                            <ArrowRight
+                                                size={16}
+                                                class="palette-item-icon"
+                                            />
+                                        {/if}
+                                        <div class="palette-item-text">
+                                            <span class="palette-item-label"
+                                                >{action.label}</span
+                                            >
+                                            {#if action.subtitle}
+                                                <span class="palette-item-subtitle"
+                                                    >{action.subtitle}</span
+                                                >
+                                            {/if}
+                                        </div>
+                                    </div>
+                                    {#if action.shortcut}
+                                        <div class="palette-item-shortcut">
+                                            {#each formatShortcut(action.shortcut) as key}
+                                                <kbd class="palette-kbd">{key}</kbd>
+                                            {/each}
+                                        </div>
                                     {/if}
                                 </div>
-                            </div>
-                            {#if action.shortcut}
-                                <div class="palette-item-shortcut">
-                                    {#each formatShortcut(action.shortcut) as key}
-                                        <kbd class="palette-kbd">{key}</kbd>
-                                    {/each}
-                                </div>
-                            {/if}
+                            {/each}
                         </div>
                     {/each}
                 {/if}
@@ -288,7 +321,7 @@
     .palette-results {
         flex: 1;
         overflow-y: auto;
-        padding: 0.5rem;
+        padding: 0.25rem;
         scrollbar-width: thin;
         scrollbar-color: var(--cds-ui-04) transparent;
     }
@@ -314,12 +347,34 @@
         font-style: italic;
     }
 
+    /* ── Group ─────────────────────────────────────────────── */
+    .palette-group {
+        padding: 0.25rem 0;
+    }
+
+    .palette-group:not(:first-child) {
+        border-top: 1px solid var(--cds-ui-03);
+        margin-top: 0.25rem;
+        padding-top: 0.5rem;
+    }
+
+    .palette-group-header {
+        font-size: 0.6875rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--cds-text-02);
+        padding: 0.25rem 0.75rem 0.375rem;
+        user-select: none;
+    }
+
+    /* ── Item ──────────────────────────────────────────────── */
     .palette-item {
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 0.75rem;
-        padding: 0.625rem 0.75rem;
+        padding: 0.5rem 0.75rem;
         border-radius: 6px;
         cursor: pointer;
         transition:

--- a/src/lib/components/app/types.ts
+++ b/src/lib/components/app/types.ts
@@ -62,6 +62,10 @@ export interface CommandAction {
     label: string;
     subtitle: string;
     shortcut: string;
+    /** Category for grouping in the palette (e.g. "Navigation", "Actions") */
+    category?: string;
+    /** Carbon icon component to display next to the label */
+    icon?: any;
     run: () => void;
 }
 

--- a/src/lib/hooks/command-palette.svelte.ts
+++ b/src/lib/hooks/command-palette.svelte.ts
@@ -5,7 +5,8 @@ import type { CommandAction } from "$lib/components/app/types";
 
 let _open = $state(false);
 let _query = $state("");
-let _actions = $state<CommandAction[]>([]);
+let _baseActions = $state<CommandAction[]>([]);
+let _dynamicActions = $state<CommandAction[]>([]);
 let _selectedIndex = $state(0);
 
 export function useCommandPalette() {
@@ -40,7 +41,20 @@ export function useCommandPalette() {
     }
 
     function registerActions(actions: CommandAction[]) {
-        _actions = actions;
+        _baseActions = actions;
+    }
+
+    function appendActions(actions: CommandAction[]) {
+        // Remove any existing actions with the same IDs first, then add new ones
+        const newIds = new Set(actions.map(a => a.id));
+        _dynamicActions = [
+            ..._dynamicActions.filter(a => !newIds.has(a.id)),
+            ...actions,
+        ];
+    }
+
+    function removeActionsByPrefix(prefix: string) {
+        _dynamicActions = _dynamicActions.filter(a => !a.id.startsWith(prefix));
     }
 
     function runAction(action: CommandAction) {
@@ -51,7 +65,7 @@ export function useCommandPalette() {
     return {
         get isOpen() { return _open; },
         get query() { return _query; },
-        get actions() { return _actions; },
+        get actions() { return [..._baseActions, ..._dynamicActions]; },
         get selectedIndex() { return _selectedIndex; },
         open,
         close,
@@ -59,6 +73,8 @@ export function useCommandPalette() {
         setQuery,
         setSelectedIndex,
         registerActions,
+        appendActions,
+        removeActionsByPrefix,
         runAction,
     };
 }

--- a/src/lib/hooks/keyboard-shortcuts.ts
+++ b/src/lib/hooks/keyboard-shortcuts.ts
@@ -1,5 +1,16 @@
 import { useCommandPalette } from "$lib/hooks/command-palette.svelte";
 import type { CommandAction } from "$lib/components/app/types";
+import {
+    Search,
+    Add,
+    Dashboard,
+    Settings,
+    Home,
+    Asleep,
+    Renew,
+    Close,
+    FolderOpen,
+} from "carbon-icons-svelte";
 
 // ── Shortcut Definitions ───────────────────────────────────────────────────
 // Each shortcut maps a key combo to a handler function.
@@ -71,6 +82,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Command Palette",
             subtitle: "Search and run commands",
             shortcut: formatShortcut({ key: "k", ctrlOrCmd: true, label: "" , run: () => {} }),
+            category: "Application",
+            icon: Search,
             run: () => { /* handled by shortcut directly */ },
         },
         {
@@ -78,6 +91,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Create Ticket",
             subtitle: "Add a new ticket to the active board",
             shortcut: formatShortcut({ key: "n", ctrlOrCmd: true, label: "", run: () => {} }),
+            category: "Actions",
+            icon: Add,
             run: callbacks.createTicket,
         },
         {
@@ -85,6 +100,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Create Board",
             subtitle: "Create a new board in the workspace",
             shortcut: formatShortcut({ key: "b", ctrlOrCmd: true, label: "", run: () => {} }),
+            category: "Actions",
+            icon: Dashboard,
             run: callbacks.createBoard,
         },
         {
@@ -92,6 +109,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Open Settings",
             subtitle: "Workspace preferences and diagnostics",
             shortcut: formatShortcut({ key: ",", ctrlOrCmd: true, label: "", run: () => {} }),
+            category: "Navigation",
+            icon: Settings,
             run: callbacks.openSettings,
         },
         {
@@ -99,6 +118,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Go to Workspace",
             subtitle: "Navigate to the workspace board list",
             shortcut: formatShortcut({ key: "h", ctrlOrCmd: true, label: "", run: () => {} }),
+            category: "Navigation",
+            icon: Home,
             run: callbacks.goToWorkspace,
         },
         {
@@ -106,6 +127,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Toggle Theme",
             subtitle: "Switch between light and dark mode",
             shortcut: formatShortcut({ key: "j", ctrlOrCmd: true, label: "", run: () => {} }),
+            category: "Application",
+            icon: Asleep,
             run: callbacks.toggleTheme,
         },
         {
@@ -113,6 +136,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Refresh Application",
             subtitle: "Reload the application window",
             shortcut: formatShortcut({ key: "r", ctrlOrCmd: true, shift: true, label: "", run: () => {} }),
+            category: "Application",
+            icon: Renew,
             run: callbacks.refreshApp,
         },
         {
@@ -120,6 +145,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Close Workspace",
             subtitle: "Close the current workspace and return to selector",
             shortcut: formatShortcut({ key: "w", ctrlOrCmd: true, shift: true, label: "", run: () => {} }),
+            category: "Workspace",
+            icon: Close,
             run: callbacks.closeWorkspace,
         },
         {
@@ -127,6 +154,8 @@ export function buildCommandActions(callbacks: AppCallbacks): CommandAction[] {
             label: "Open Workspace",
             subtitle: "Open a different workspace folder",
             shortcut: formatShortcut({ key: "o", ctrlOrCmd: true, label: "", run: () => {} }),
+            category: "Workspace",
+            icon: FolderOpen,
             run: callbacks.openWorkspace,
         },
     ];

--- a/src/routes/workspace/+layout.svelte
+++ b/src/routes/workspace/+layout.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
     import { Content } from "carbon-components-svelte";
+    import { Dashboard } from "carbon-icons-svelte";
 
     import WorkspaceSidebar from "$lib/components/app/layout/workspace/workspace-sidebar.svelte";
     import { useBoards } from "$lib/hooks/boards.svelte";
     import { setWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
     import { useWorkspace } from "$lib/hooks/workspace.svelte";
+    import { useCommandPalette } from "$lib/hooks/command-palette.svelte";
     import { page } from "$app/state";
+    import type { CommandAction } from "$lib/components/app/types";
 
     let { children } = $props();
     const workspace = useWorkspace();
     const boardsApi = useBoards(() => workspace.path);
+    const palette = useCommandPalette();
 
     setWorkspaceShellContext({ workspace, boardsApi });
 
@@ -52,6 +56,35 @@
         void boardsApi.load().catch((error) => {
             boardLoadError = String(error);
             lastLoadedWorkspacePath = null;
+        });
+    });
+
+    // ── Dynamic board-switching commands ────────────────────────────────────
+    $effect(() => {
+        // Read the reactive dependency
+        const boards = boardsApi.boards;
+
+        // Build new board actions (or empty list if no boards)
+        const boardActions: CommandAction[] = boards.map((board) => ({
+            id: `switch-board-${board.id}`,
+            label: `Switch to: ${board.name}`,
+            subtitle: board.description || "Open this board",
+            shortcut: "",
+            category: "Boards",
+            icon: Dashboard,
+            run: () => {
+                boardsApi.setActive(board);
+                void goto(`/workspace/${board.id}`);
+            },
+        }));
+
+        // Use queueMicrotask to defer state writes so they don't
+        // trigger re-entry into this effect synchronously
+        queueMicrotask(() => {
+            palette.removeActionsByPrefix("switch-board-");
+            if (boardActions.length > 0) {
+                palette.appendActions(boardActions);
+            }
         });
     });
 


### PR DESCRIPTION
This pull request introduces major improvements to the command palette, focusing on grouping commands by category, enhancing visual clarity, and enabling dynamic addition/removal of actions (such as board-switching commands). It also adds support for icons and categories in commands, and updates the UI to reflect these changes.

**Command Palette Grouping and UI Enhancements:**

* The command palette UI now groups commands by their `category` property, displaying a header for each group and preserving the insertion order within groups. This improves discoverability and organization of actions. (`src/lib/components/app/layout/command-palette/command-palette.svelte` [[1]](diffhunk://#diff-25da7a10cdd9f42563ed9f9db93916588cbad861dbf37cc241eedf75f804915bR27-R47) [[2]](diffhunk://#diff-25da7a10cdd9f42563ed9f9db93916588cbad861dbf37cc241eedf75f804915bL127-R182) [[3]](diffhunk://#diff-25da7a10cdd9f42563ed9f9db93916588cbad861dbf37cc241eedf75f804915bR203-R204) [[4]](diffhunk://#diff-25da7a10cdd9f42563ed9f9db93916588cbad861dbf37cc241eedf75f804915bL291-R324) [[5]](diffhunk://#diff-25da7a10cdd9f42563ed9f9db93916588cbad861dbf37cc241eedf75f804915bR350-R377)
* Each command can now display a custom icon (from Carbon icons) next to its label, or a default arrow if none is provided. (`src/lib/components/app/layout/command-palette/command-palette.svelte` [[1]](diffhunk://#diff-25da7a10cdd9f42563ed9f9db93916588cbad861dbf37cc241eedf75f804915bL127-R182) [[2]](diffhunk://#diff-e7801835a5a3da6affad49ae4e96b5d8e1de043f6c4620308353dc01094f8cbaR65-R68) [[3]](diffhunk://#diff-8fce1cc2bb0aa9731d1237328b3ef0dcaef09410346ef14b80cbb1f11b9af3abR3-R13) [[4]](diffhunk://#diff-8fce1cc2bb0aa9731d1237328b3ef0dcaef09410346ef14b80cbb1f11b9af3abR85-R158)

**Command Action Model and API Changes:**

* The `CommandAction` interface now includes optional `category` and `icon` fields to support grouping and icon display. (`src/lib/components/app/types.ts` [src/lib/components/app/types.tsR65-R68](diffhunk://#diff-e7801835a5a3da6affad49ae4e96b5d8e1de043f6c4620308353dc01094f8cbaR65-R68))
* The command palette hook (`useCommandPalette`) now separates base actions from dynamic actions, and provides new methods: `appendActions` (to add dynamic actions), and `removeActionsByPrefix` (to remove actions by ID prefix). The `actions` getter now returns a merged list of base and dynamic actions. (`src/lib/hooks/command-palette.svelte.ts` [[1]](diffhunk://#diff-82ce79645e3dc8a5b7c20c8a676a134e0afae428be8fff29669a359e8a086af9L8-R9) [[2]](diffhunk://#diff-82ce79645e3dc8a5b7c20c8a676a134e0afae428be8fff29669a359e8a086af9L43-R57) [[3]](diffhunk://#diff-82ce79645e3dc8a5b7c20c8a676a134e0afae428be8fff29669a359e8a086af9L54-R77)

**Dynamic Board-Switching Commands:**

* In the workspace layout, dynamic command actions are generated for switching between boards. These actions are updated reactively when the list of boards changes, and are added/removed from the palette using the new API. (`src/routes/workspace/+layout.svelte` [[1]](diffhunk://#diff-547e6f6c968a82771cbeb6ca3f473e1770049a4719c79553204dc5fd72490c99R4-R17) [[2]](diffhunk://#diff-547e6f6c968a82771cbeb6ca3f473e1770049a4719c79553204dc5fd72490c99R62-R90)

**Command Definitions Update:**

* All built-in command actions now specify appropriate `category` and `icon` properties, so they are grouped and visually enhanced in the palette. (`src/lib/hooks/keyboard-shortcuts.ts` [src/lib/hooks/keyboard-shortcuts.tsR85-R158](diffhunk://#diff-8fce1cc2bb0aa9731d1237328b3ef0dcaef09410346ef14b80cbb1f11b9af3abR85-R158))

These changes collectively make the command palette more scalable, visually organized, and extensible for future dynamic commands.