### PR TITLE
fix : Refactor overdue logic to exclude completed tickets in views

### DIFF
--- a/src/lib/components/app/gantt/gantt-state.svelte.ts
+++ b/src/lib/components/app/gantt/gantt-state.svelte.ts
@@ -219,6 +219,11 @@ export class GanttState {
         const now = new Date();
         if (!ticket.due_date) return "No due date";
         const diff = Math.ceil((new Date(ticket.due_date).getTime() - now.getTime()) / this.DAY_MS);
+
+        if (ticket.status === "done") {
+            return "Completed";
+        }
+
         if (diff < 0) return `${Math.abs(diff)}d overdue`;
         if (diff === 0) return "Due today";
         if (diff === 1) return "Tomorrow";

--- a/src/lib/components/app/kanban/kanban-ticket-card.svelte
+++ b/src/lib/components/app/kanban/kanban-ticket-card.svelte
@@ -67,6 +67,19 @@
 
     let cardElement = $state<HTMLElement>();
 
+    const isOverdue = $derived.by(() => {
+        if (!ticket.due_date || ticket.status === "done") return false;
+        
+        // Strip time from both dates for accurate day comparison
+        const due = new Date(ticket.due_date);
+        due.setHours(0, 0, 0, 0);
+        
+        const now = new Date();
+        now.setHours(0, 0, 0, 0);
+        
+        return due < now;
+    });
+
     function copyToClipboard(text: string) {
         if (navigator.clipboard) {
             void navigator.clipboard.writeText(text);
@@ -152,7 +165,7 @@
                     </span>
                 {/if}
                 {#if ticket.due_date}
-                    <span class="meta-item">
+                    <span class="meta-item" class:overdue={isOverdue}>
                         <Calendar size={14} />
                         <span>{ticket.due_date}</span>
                     </span>
@@ -310,5 +323,10 @@
         gap: 0.25rem;
         font-size: 0.6875rem;
         color: var(--cds-text-helper);
+    }
+
+    .meta-item.overdue {
+        color: var(--cds-support-01);
+        font-weight: 500;
     }
 </style>

--- a/src/lib/components/app/table/table-group.svelte
+++ b/src/lib/components/app/table/table-group.svelte
@@ -58,6 +58,7 @@
                         labels: t.labels,
                         dueDate: t.due_date,
                         created: t.created_at,
+                        status: t.status,
                     }))}
                     sort={state.customSort}
                 >
@@ -107,7 +108,7 @@
                                 {/if}
                             </div>
                         {:else if cell.key === "dueDate"}
-                            {@const due = state.formatDueDate(cell.value)}
+                            {@const due = state.formatDueDate(cell.value, row.status === "done")}
                             <div class="cell-due" class:overdue={due.overdue}>
                                 <Calendar size={14} />
                                 <span>{due.text}</span>

--- a/src/lib/components/app/table/table-state.svelte.ts
+++ b/src/lib/components/app/table/table-state.svelte.ts
@@ -66,13 +66,13 @@ export class TableState {
     get filteredTickets(): Ticket[] {
         return this.searchQuery.trim()
             ? this.#ticketsHook.tickets.filter(
-                  (t: Ticket) =>
-                      t.title.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
-                      t.description?.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
-                      t.labels?.some((tag: string) =>
-                          tag.toLowerCase().includes(this.searchQuery.toLowerCase()),
-                      ),
-              )
+                (t: Ticket) =>
+                    t.title.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
+                    t.description?.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
+                    t.labels?.some((tag: string) =>
+                        tag.toLowerCase().includes(this.searchQuery.toLowerCase()),
+                    ),
+            )
             : this.#ticketsHook.tickets;
     }
 
@@ -123,7 +123,7 @@ export class TableState {
         });
     }
 
-    formatDueDate(dateStr: string | null): {
+    formatDueDate(dateStr: string | null, isDone: boolean = false): {
         text: string;
         overdue: boolean;
     } {
@@ -136,7 +136,7 @@ export class TableState {
         if (diffDays < 0)
             return {
                 text: `${Math.abs(diffDays)}d overdue`,
-                overdue: true,
+                overdue: !isDone,
             };
         if (diffDays === 0) return { text: "Due today", overdue: false };
         if (diffDays === 1) return { text: "Tomorrow", overdue: false };


### PR DESCRIPTION
This pull request improves how ticket due dates and overdue statuses are displayed across the Gantt, Kanban, and Table views. It ensures that completed tickets are not marked as overdue and visually distinguishes overdue tickets in the Kanban view.

**Due Date and Status Handling:**

* Updated `GanttState` to display "Completed" for tickets with status `"done"`, regardless of due date.
* Modified `TableState.formatDueDate` to accept an `isDone` parameter and prevent marking completed tickets as overdue. [[1]](diffhunk://#diff-c67a48bcd18c9a36c8567fe64e972bd5d993ca0f23b40c5f4e9b51c1466e9065L126-R126) [[2]](diffhunk://#diff-c67a48bcd18c9a36c8567fe64e972bd5d993ca0f23b40c5f4e9b51c1466e9065L139-R139)
* Passed ticket status to the Table component for accurate due date formatting. [[1]](diffhunk://#diff-194131ce9901541a2596aa3ac64e57cfbe0dbd94ff6c6b1b3cf9f6088ab6be6eR61) [[2]](diffhunk://#diff-194131ce9901541a2596aa3ac64e57cfbe0dbd94ff6c6b1b3cf9f6088ab6be6eL110-R111)

**Kanban View Visual Improvements:**

* Added logic in `kanban-ticket-card.svelte` to detect overdue tickets, ignoring those marked as `"done"`.
* Applied a distinct style to overdue due dates in Kanban cards for better visibility. [[1]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacL155-R168) [[2]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacR327-R331)