### PR TITLE
Add context menu options for updating ticket status from board

### DIFF
--- a/src/lib/components/app/kanban/kanban-board.svelte
+++ b/src/lib/components/app/kanban/kanban-board.svelte
@@ -229,6 +229,15 @@
         }
     }
 
+    async function handleStatusChange(id: string, status: TicketStatus) {
+        try {
+            actionError = null;
+            await ticketsHook.update(id, { status });
+        } catch (error) {
+            actionError = String(error);
+        }
+    }
+
     // ── Stats (exclude backlog from progress) ─────────────────────────────────
     const activeTickets = $derived(
         columns
@@ -323,6 +332,7 @@
                 onAddTicket={openAddModal}
                 onEditTicket={openEditModal}
                 onDeleteTicket={promptDeleteTicket}
+                onStatusChange={handleStatusChange}
             />
         {/each}
     </div>

--- a/src/lib/components/app/kanban/kanban-column.svelte
+++ b/src/lib/components/app/kanban/kanban-column.svelte
@@ -24,6 +24,7 @@
         onAddTicket,
         onEditTicket,
         onDeleteTicket,
+        onStatusChange,
     }: {
         label: string;
         status: TicketStatus;
@@ -35,6 +36,7 @@
         onAddTicket?: (status: TicketStatus) => void;
         onEditTicket?: (ticket: Ticket) => void;
         onDeleteTicket?: (id: string) => void;
+        onStatusChange?: (id: string, status: TicketStatus) => void;
     } = $props();
 
     const flipDurationMs = 180;
@@ -124,6 +126,7 @@
                         {ticket}
                         onEdit={onEditTicket}
                         onDelete={onDeleteTicket}
+                        {onStatusChange}
                     />
                 </div>
             {/each}

--- a/src/lib/components/app/kanban/kanban-ticket-card.svelte
+++ b/src/lib/components/app/kanban/kanban-ticket-card.svelte
@@ -27,6 +27,7 @@
     } from "carbon-icons-svelte";
     import {
         type Ticket,
+        type TicketStatus,
         type TicketPriority,
         type TicketType,
         TICKET_TYPE_CONFIG,
@@ -37,10 +38,12 @@
         ticket,
         onEdit,
         onDelete,
+        onStatusChange,
     }: {
         ticket: Ticket;
         onEdit?: (ticket: Ticket) => void;
         onDelete?: (id: string) => void;
+        onStatusChange?: (id: string, status: TicketStatus) => void;
     } = $props();
 
     // Carbon icon map for ticket types
@@ -76,11 +79,47 @@
 
 <article class="ticket-card" bind:this={cardElement}>
     <ContextMenu target={cardElement ? [cardElement] : []}>
-        <ContextMenuOption labelText="Copy Ticket ID" icon={CopyFile} on:click={() => copyToClipboard(ticket.id)} />
-        <ContextMenuOption labelText="Copy Title" icon={CopyFile} on:click={() => copyToClipboard(ticket.title)} />
+        <ContextMenuOption
+            labelText="Copy Ticket ID"
+            icon={CopyFile}
+            on:click={() => copyToClipboard(ticket.id)}
+        />
+        <ContextMenuOption
+            labelText="Copy Title"
+            icon={CopyFile}
+            on:click={() => copyToClipboard(ticket.title)}
+        />
         <ContextMenuDivider />
-        <ContextMenuOption labelText="Edit Ticket" icon={Edit} on:click={() => onEdit?.(ticket)} />
-        <ContextMenuOption kind="danger" labelText="Delete Ticket" icon={TrashCan} on:click={() => onDelete?.(ticket.id)} />
+        <ContextMenuOption labelText="Move to..." icon={ArrowRight}>
+            <ContextMenuOption
+                labelText="Backlog"
+                on:click={() => onStatusChange?.(ticket.id, "backlog")}
+            />
+            <ContextMenuOption
+                labelText="Todo"
+                on:click={() => onStatusChange?.(ticket.id, "todo")}
+            />
+            <ContextMenuOption
+                labelText="In Progress"
+                on:click={() => onStatusChange?.(ticket.id, "in_progress")}
+            />
+            <ContextMenuOption
+                labelText="Done"
+                on:click={() => onStatusChange?.(ticket.id, "done")}
+            />
+        </ContextMenuOption>
+        <ContextMenuDivider />
+        <ContextMenuOption
+            labelText="Edit Ticket"
+            icon={Edit}
+            on:click={() => onEdit?.(ticket)}
+        />
+        <ContextMenuOption
+            kind="danger"
+            labelText="Delete Ticket"
+            icon={TrashCan}
+            on:click={() => onDelete?.(ticket.id)}
+        />
     </ContextMenu>
 
     <!-- Drag handle -->


### PR DESCRIPTION
This pull request adds a new feature to the Kanban board, allowing users to change a ticket’s status directly from the ticket card’s context menu. The update involves propagating a new `onStatusChange` handler through the Kanban board, column, and ticket card components, and implementing the corresponding logic for updating ticket status.

**Feature: Move ticket to another status from context menu**

* Added a `Move to...` submenu in the ticket card context menu, enabling users to move a ticket to any status (Backlog, Todo, In Progress, Done) via `onStatusChange` handler.
* Introduced the `onStatusChange` callback prop in `kanban-ticket-card.svelte`, `kanban-column.svelte`, and `kanban-board.svelte` components, and passed it through the component hierarchy. [[1]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacR41-R46) [[2]](diffhunk://#diff-bdb2aadf0e495bcca08afb52ddcff4320ffca8a8bc53c4fc557f7134b6efe336R27) [[3]](diffhunk://#diff-bdb2aadf0e495bcca08afb52ddcff4320ffca8a8bc53c4fc557f7134b6efe336R39) [[4]](diffhunk://#diff-bdb2aadf0e495bcca08afb52ddcff4320ffca8a8bc53c4fc557f7134b6efe336R129) [[5]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980R335)
* Implemented the `handleStatusChange` async function in `kanban-board.svelte` to update the ticket status and handle errors.

**Type improvements**

* Added `TicketStatus` type import and usage where appropriate for improved type safety.…the board