### PR TITLE
Add start_date support for interactive drag-to-resize on Gantt chart

### DIFF
--- a/src/lib/components/app/gantt/gantt-canvas.svelte
+++ b/src/lib/components/app/gantt/gantt-canvas.svelte
@@ -6,31 +6,47 @@
 
     let { onTicketClick }: { onTicketClick: (ticket: Ticket) => void } = $props();
 
-    // ── Drag-resize state (local so Svelte reactivity is guaranteed) ──────
+    // ── Drag-resize state ────────────────────────────────────────────────
+    type DragEdge = "left" | "right";
     let dragTicketId = $state<string | null>(null);
+    let dragEdge = $state<DragEdge>("right");
     let dragStartX = 0;
     let dragOriginalWidth = 0;
+    let dragOriginalLeft = 0;
     let dragCurrentWidth = $state(0);
-    let dragBarLeft = 0;
+    let dragCurrentLeft = $state(0);
     let wasDragging = $state(false);
 
-    function onResizeStart(e: MouseEvent, ticket: Ticket) {
+    function onResizeStart(e: MouseEvent, ticket: Ticket, edge: DragEdge) {
         e.preventDefault();
         e.stopPropagation();
 
         dragTicketId = ticket.id;
+        dragEdge = edge;
         wasDragging = false;
         dragStartX = e.clientX;
         dragOriginalWidth = s.getBarWidth(ticket);
+        dragOriginalLeft = s.getBarLeft(ticket);
         dragCurrentWidth = dragOriginalWidth;
-        dragBarLeft = s.getBarLeft(ticket);
+        dragCurrentLeft = dragOriginalLeft;
         s.dragTicketId = ticket.id;
         s.hoveredTicketId = null;
 
         const onMove = (ev: MouseEvent) => {
             const dx = ev.clientX - dragStartX;
-            dragCurrentWidth = Math.max(s.colWidth, dragOriginalWidth + dx);
             if (Math.abs(dx) > 2) wasDragging = true;
+
+            if (edge === "right") {
+                dragCurrentWidth = Math.max(s.colWidth, dragOriginalWidth + dx);
+            } else {
+                // Left edge: move left, expand width inversely
+                const newLeft = dragOriginalLeft + dx;
+                const newWidth = dragOriginalWidth - dx;
+                if (newWidth >= s.colWidth) {
+                    dragCurrentLeft = newLeft;
+                    dragCurrentWidth = newWidth;
+                }
+            }
         };
 
         const onUp = async () => {
@@ -39,15 +55,21 @@
 
             const ticketId = dragTicketId;
             const moved = wasDragging;
+            const currentEdge = dragEdge;
             dragTicketId = null;
             s.dragTicketId = null;
 
             if (ticketId && moved) {
-                const newDue = s.getDragDueDate(dragBarLeft, dragCurrentWidth);
                 try {
-                    await s.updateDueDate(ticketId, newDue);
+                    if (currentEdge === "right") {
+                        const newDue = s.getDragDueDate(dragCurrentLeft, dragCurrentWidth);
+                        await s.updateDueDate(ticketId, newDue);
+                    } else {
+                        const newStart = s.getDragStartDate(dragCurrentLeft);
+                        await s.updateStartDate(ticketId, newStart);
+                    }
                 } catch (err) {
-                    console.error("Failed to update due date:", err);
+                    console.error("Failed to update date:", err);
                 }
             }
 
@@ -106,7 +128,7 @@
                 ></div>
             {:else}
                 {@const isDragging = dragTicketId === row.ticket.id}
-                {@const barLeft = s.getBarLeft(row.ticket)}
+                {@const barLeft = isDragging ? dragCurrentLeft : s.getBarLeft(row.ticket)}
                 {@const barWidth = isDragging ? dragCurrentWidth : s.getBarWidth(row.ticket)}
                 <div
                     class="canvas-row"
@@ -134,14 +156,25 @@
                         <span class="bar-label">{row.ticket.title}</span>
                     </div>
 
-                    <!-- Resize handle — outside bar so overflow:hidden doesn't interfere -->
+                    <!-- Left resize handle (start date) -->
                     <!-- svelte-ignore a11y_no_static_element_interactions -->
                     <!-- svelte-ignore a11y_click_events_have_key_events -->
                     <div
-                        class="bar-resize-handle"
-                        class:handle--dragging={isDragging}
+                        class="bar-resize-handle bar-resize-handle--left"
+                        class:handle--dragging={isDragging && dragEdge === "left"}
+                        style="left:{barLeft - 4}px"
+                        onmousedown={(e) => onResizeStart(e, row.ticket, "left")}
+                        onclick={(e) => e.stopPropagation()}
+                    ></div>
+
+                    <!-- Right resize handle (due date) -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <div
+                        class="bar-resize-handle bar-resize-handle--right"
+                        class:handle--dragging={isDragging && dragEdge === "right"}
                         style="left:{barLeft + barWidth - 6}px"
-                        onmousedown={(e) => onResizeStart(e, row.ticket)}
+                        onmousedown={(e) => onResizeStart(e, row.ticket, "right")}
                         onclick={(e) => e.stopPropagation()}
                     ></div>
                 </div>
@@ -228,7 +261,7 @@
     }
     .bar--dragging { z-index: 10; outline: 1px solid var(--cds-interactive-01); }
 
-    /* ── Resize handle ─────────────────────────────────── */
+    /* ── Resize handles ─────────────────────────────────── */
     .bar-resize-handle {
         position: absolute;
         top: 5px; height: 26px; width: 10px;

--- a/src/lib/components/app/gantt/gantt-state.svelte.ts
+++ b/src/lib/components/app/gantt/gantt-state.svelte.ts
@@ -90,14 +90,14 @@ export class GanttState {
         let minDate = now.getTime();
         let maxDate = now.getTime();
         for (const t of tickets) {
-            const created = new Date(t.created_at).getTime();
-            if (created < minDate) minDate = created;
+            const start = new Date(t.start_date ?? t.created_at).getTime();
+            if (start < minDate) minDate = start;
+            if (start > maxDate) maxDate = start;
             if (t.due_date) {
                 const due = new Date(t.due_date).getTime();
                 if (due > maxDate) maxDate = due;
                 if (due < minDate) minDate = due;
             }
-            if (created > maxDate) maxDate = created;
         }
         const pad = 3 * this.DAY_MS;
         return {
@@ -186,27 +186,27 @@ export class GanttState {
 
     getBarLeft(ticket: Ticket): number {
         const rangeStart = this.timeRange.start.getTime();
-        const created = new Date(ticket.created_at).getTime();
-        return Math.max(0, (created - rangeStart) / this.DAY_MS) * this.colWidth;
+        const start = new Date(ticket.start_date ?? ticket.created_at).getTime();
+        return Math.max(0, (start - rangeStart) / this.DAY_MS) * this.colWidth;
     }
 
     getBarWidth(ticket: Ticket): number {
         const now = new Date();
-        const created = new Date(ticket.created_at).getTime();
+        const start = new Date(ticket.start_date ?? ticket.created_at).getTime();
         if (!ticket.due_date) {
-            return Math.max(this.colWidth, ((now.getTime() - created) / this.DAY_MS) * this.colWidth);
+            return Math.max(this.colWidth, ((now.getTime() - start) / this.DAY_MS) * this.colWidth);
         }
         const due = new Date(ticket.due_date).getTime();
-        return Math.max(this.colWidth, ((due - created) / this.DAY_MS) * this.colWidth);
+        return Math.max(this.colWidth, ((due - start) / this.DAY_MS) * this.colWidth);
     }
 
     getElapsedPercent(ticket: Ticket): number {
         const now = new Date();
         if (!ticket.due_date) return 100;
-        const created = new Date(ticket.created_at).getTime();
+        const start = new Date(ticket.start_date ?? ticket.created_at).getTime();
         const due = new Date(ticket.due_date).getTime();
-        if (due <= created) return 100;
-        return Math.min(100, Math.max(0, ((now.getTime() - created) / (due - created)) * 100));
+        if (due <= start) return 100;
+        return Math.min(100, Math.max(0, ((now.getTime() - start) / (due - start)) * 100));
     }
 
     isOverdue(ticket: Ticket): boolean {
@@ -247,8 +247,18 @@ export class GanttState {
         return newDue.toISOString().split("T")[0];
     }
 
+    getDragStartDate(barLeftPx: number): string {
+        const dayOffset = barLeftPx / this.colWidth;
+        const newStart = new Date(this.timeRange.start.getTime() + dayOffset * this.DAY_MS);
+        return newStart.toISOString().split("T")[0];
+    }
+
     async updateDueDate(ticketId: string, dueDate: string) {
         await this.#ticketsHook.update(ticketId, { due_date: dueDate });
+    }
+
+    async updateStartDate(ticketId: string, startDate: string) {
+        await this.#ticketsHook.update(ticketId, { start_date: startDate });
     }
 }
 

--- a/src/lib/components/app/gantt/gantt-tooltip.svelte
+++ b/src/lib/components/app/gantt/gantt-tooltip.svelte
@@ -39,9 +39,22 @@
                 >{state.getDaysLeft(state.hoveredTicket)}</span
             >
         </div>
+        {#if state.hoveredTicket.start_date}
+            <div class="tip-row">
+                <Calendar size={12} />
+                <span class="tip-label">Start</span>
+                <span class="tip-val"
+                    >{new Date(state.hoveredTicket.start_date).toLocaleDateString(
+                        "en-US",
+                        { month: "short", day: "numeric", year: "numeric" },
+                    )}</span
+                >
+            </div>
+        {/if}
         {#if state.hoveredTicket.due_date}
             <div class="tip-row">
                 <Calendar size={12} />
+                <span class="tip-label">Due</span>
                 <span class="tip-val"
                     >{new Date(state.hoveredTicket.due_date).toLocaleDateString(
                         "en-US",

--- a/src/lib/components/app/kanban/kanban-board.svelte
+++ b/src/lib/components/app/kanban/kanban-board.svelte
@@ -188,6 +188,7 @@
                 description: data.description,
                 priority: data.priority,
                 ticket_type: data.ticketType,
+                start_date: data.startDate || null,
                 due_date: data.dueDate || null,
                 labels: data.tags,
             });
@@ -199,6 +200,7 @@
                 status: data.status,
                 priority: data.priority,
                 ticket_type: data.ticketType,
+                start_date: data.startDate || null,
                 due_date: data.dueDate || null,
                 labels: data.tags,
             });

--- a/src/lib/components/app/kanban/ticket-add-edit-modal.svelte
+++ b/src/lib/components/app/kanban/ticket-add-edit-modal.svelte
@@ -32,6 +32,7 @@
             description: string;
             priority: TicketPriority;
             ticketType: TicketType;
+            startDate: string;
             dueDate: string;
             tags: string[];
             status: TicketStatus;
@@ -49,6 +50,7 @@
         description: string;
         priority: TicketPriority;
         ticketType: TicketType;
+        startDate: string;
         dueDate: string;
         tags: string[];
     }>({
@@ -56,6 +58,7 @@
         description: "",
         priority: "p2",
         ticketType: "feature",
+        startDate: "",
         dueDate: "",
         tags: [],
     });
@@ -86,6 +89,7 @@
                     description: ticket.description,
                     priority: ticket.priority,
                     ticketType: ticket.ticket_type,
+                    startDate: ticket.start_date ?? "",
                     dueDate: ticket.due_date ?? "",
                     tags: ticket.labels ?? [],
                 };
@@ -95,6 +99,7 @@
                     description: "",
                     priority: "p2",
                     ticketType: "feature",
+                    startDate: "",
                     dueDate: "",
                     tags: [],
                 };
@@ -113,6 +118,7 @@
                 description: form.description || "",
                 priority: form.priority,
                 ticketType: form.ticketType,
+                startDate: form.startDate,
                 dueDate: form.dueDate,
                 tags: form.tags,
                 status: defaultStatus,
@@ -171,6 +177,16 @@
             />
         </div>
         <div class="form-row">
+            <DatePicker
+                bind:value={form.startDate}
+                datePickerType="single"
+                dateFormat="Y-m-d"
+            >
+                <DatePickerInput
+                    labelText="Start Date"
+                    placeholder="yyyy-mm-dd"
+                />
+            </DatePicker>
             <DatePicker
                 bind:value={form.dueDate}
                 datePickerType="single"

--- a/src/lib/components/app/types.ts
+++ b/src/lib/components/app/types.ts
@@ -116,6 +116,7 @@ export interface Ticket {
     ticket_type: TicketType;
     position: number;
     due_date: string | null;
+    start_date: string | null;
     labels: string[];
     comments: Comment[];
     created_at: string;
@@ -128,7 +129,7 @@ export type CreateTicketInput = Pick<
     Ticket,
     "board_id" | "title" | "description" | "labels"
 > &
-    Partial<Pick<Ticket, "status" | "priority" | "ticket_type" | "position" | "due_date">>;
+    Partial<Pick<Ticket, "status" | "priority" | "ticket_type" | "position" | "due_date" | "start_date">>;
 export type UpdateTicketInput = Partial<
     Pick<
         Ticket,
@@ -139,6 +140,7 @@ export type UpdateTicketInput = Partial<
         | "ticket_type"
         | "position"
         | "due_date"
+        | "start_date"
         | "labels"
         | "comments"
     >

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -217,6 +217,15 @@ async function migrate_v6(db: Database): Promise<void> {
     await db.execute(`CREATE INDEX IF NOT EXISTS idx_tickets_position ON tickets(position)`);
 }
 
+async function migrate_v7(db: Database): Promise<void> {
+    // Add start_date column for Gantt start date support
+    const columns = await db.select<Array<{ name: string }>>(`PRAGMA table_info(tickets)`);
+    const hasStartDate = columns.some((column) => column.name === 'start_date');
+    if (!hasStartDate) {
+        await db.execute(`ALTER TABLE tickets ADD COLUMN start_date TEXT`);
+    }
+}
+
 export async function runMigrations(db: Database): Promise<void> {
     const rows = await db.select<{ schema_version: number }[]>(
         `SELECT schema_version FROM workspace_meta WHERE id = 1`
@@ -244,6 +253,10 @@ export async function runMigrations(db: Database): Promise<void> {
 
     if (current < 6) {
         await migrate_v6(db);
+    }
+
+    if (current < 7) {
+        await migrate_v7(db);
     }
 
     await db.execute(

--- a/src/lib/db/repositories/ticket.repo.ts
+++ b/src/lib/db/repositories/ticket.repo.ts
@@ -9,6 +9,7 @@ function deserialize(row: any): Ticket {
         priority: row.priority ?? 'p2',
         ticket_type: row.ticket_type ?? 'feature',
         due_date: row.due_date ?? null,
+        start_date: row.start_date ?? null,
         labels: typeof row.labels === 'string' ? JSON.parse(row.labels) : row.labels,
         comments: typeof row.comments === 'string' ? JSON.parse(row.comments) : row.comments,
     };
@@ -50,6 +51,7 @@ export async function createTicket(db: Database, input: CreateTicketInput): Prom
         ticket_type: input.ticket_type ?? 'feature',
         position,
         due_date: input.due_date ?? null,
+        start_date: input.start_date ?? null,
         labels: input.labels ?? [],
         comments: [],
         created_at: new Date().toISOString(),
@@ -57,8 +59,8 @@ export async function createTicket(db: Database, input: CreateTicketInput): Prom
     };
 
     await db.execute(
-        `INSERT INTO tickets (id, board_id, title, description, status, priority, ticket_type, position, due_date, labels, comments, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO tickets (id, board_id, title, description, status, priority, ticket_type, position, due_date, start_date, labels, comments, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
             ticket.id, ticket.board_id, ticket.title, ticket.description,
             ticket.status,
@@ -66,6 +68,7 @@ export async function createTicket(db: Database, input: CreateTicketInput): Prom
             ticket.ticket_type,
             ticket.position,
             ticket.due_date,
+            ticket.start_date,
             JSON.stringify(ticket.labels),
             JSON.stringify(ticket.comments),
             ticket.created_at, ticket.updated_at
@@ -87,7 +90,7 @@ export async function updateTicket(db: Database, id: string, input: UpdateTicket
 
     await db.execute(
         `UPDATE tickets
-     SET title = ?, description = ?, status = ?, priority = ?, ticket_type = ?, position = ?, due_date = ?, labels = ?, comments = ?, updated_at = ?
+     SET title = ?, description = ?, status = ?, priority = ?, ticket_type = ?, position = ?, due_date = ?, start_date = ?, labels = ?, comments = ?, updated_at = ?
      WHERE id = ?`,
         [
             updated.title, updated.description, updated.status,
@@ -95,6 +98,7 @@ export async function updateTicket(db: Database, id: string, input: UpdateTicket
             updated.ticket_type,
             updated.position,
             updated.due_date,
+            updated.start_date,
             JSON.stringify(updated.labels),
             JSON.stringify(updated.comments),
             updated.updated_at, id

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 6;
+export const SCHEMA_VERSION = 7;
 
 export const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS workspace_meta (
@@ -30,6 +30,7 @@ export const CREATE_TABLES = `
                 CHECK (ticket_type IN ('feature', 'bug', 'chore', 'improvement', 'epic', 'spike')),
     position    REAL NOT NULL DEFAULT 0,
     due_date    TEXT,
+    start_date  TEXT,
     labels      TEXT NOT NULL DEFAULT '[]',
     comments    TEXT NOT NULL DEFAULT '[]',
     created_at  TEXT NOT NULL,


### PR DESCRIPTION
This pull request introduces support for ticket start dates in the Kanban and Gantt chart features. It adds a `start_date` field to tickets, updates the database schema and data access layers, and enables interactive editing of both start and due dates directly from the Gantt chart. The UI and tooltips are updated to display and allow input of start dates, providing more accurate scheduling and visualization.

**Gantt Chart Enhancements:**

- Added interactive left and right resize handles to Gantt bars, allowing users to adjust both start and due dates by dragging. The left handle updates the start date, and the right handle updates the due date. [[1]](diffhunk://#diff-ceb57f3e5f959cd31c21adcdc8f87d730ad5bfb4ba779a64a40190d691add4fdL9-R49) [[2]](diffhunk://#diff-ceb57f3e5f959cd31c21adcdc8f87d730ad5bfb4ba779a64a40190d691add4fdR58-R72) [[3]](diffhunk://#diff-ceb57f3e5f959cd31c21adcdc8f87d730ad5bfb4ba779a64a40190d691add4fdL109-R131) [[4]](diffhunk://#diff-ceb57f3e5f959cd31c21adcdc8f87d730ad5bfb4ba779a64a40190d691add4fdL137-R177)
- Updated Gantt bar positioning and width calculations to use `start_date` instead of `created_at`, ensuring accurate visual representation. [[1]](diffhunk://#diff-e5b6db061d19445b3fc0e23b4538f9c10da37c9003d4aa97e312a78826faea5cL93-L100) [[2]](diffhunk://#diff-e5b6db061d19445b3fc0e23b4538f9c10da37c9003d4aa97e312a78826faea5cL189-R209)
- Tooltip now displays the start date if present, alongside the due date.

**Kanban Board and Ticket Modal Updates:**

- Added `startDate` support to the ticket add/edit modal, allowing users to set or edit the start date when creating or updating tickets. [[1]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR35) [[2]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR53-R61) [[3]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR92) [[4]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR102) [[5]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR121) [[6]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR180-R189)
- Kanban board now handles `start_date` when creating or updating tickets. [[1]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980R191) [[2]](diffhunk://#diff-1a6e953ae2a28ace74e633ac8dd36ab9194637218d31bfe1246a89523d66a980R203)

**Data Model and Database Changes:**

- Extended the `Ticket` type and related input types to include `start_date`. [[1]](diffhunk://#diff-e7801835a5a3da6affad49ae4e96b5d8e1de043f6c4620308353dc01094f8cbaR119) [[2]](diffhunk://#diff-e7801835a5a3da6affad49ae4e96b5d8e1de043f6c4620308353dc01094f8cbaL131-R132) [[3]](diffhunk://#diff-e7801835a5a3da6affad49ae4e96b5d8e1de043f6c4620308353dc01094f8cbaR143)
- Added a new database migration (`migrate_v7`) to add the `start_date` column to the tickets table. [[1]](diffhunk://#diff-25fe054c6a901aed0159575e0676fa7be7a3a06d386285e0222482fef94384c1R220-R228) [[2]](diffhunk://#diff-25fe054c6a901aed0159575e0676fa7be7a3a06d386285e0222482fef94384c1R258-R261)
- Updated ticket repository methods to read, write, and update the `start_date` field. [[1]](diffhunk://#diff-8be4bd77e4584f44a2b914da01a8b7af2580d165e567f5a5f630fc6ffd2f3dbeR12) [[2]](diffhunk://#diff-8be4bd77e4584f44a2b914da01a8b7af2580d165e567f5a5f630fc6ffd2f3dbeR54-R71) [[3]](diffhunk://#diff-8be4bd77e4584f44a2b914da01a8b7af2580d165e567f5a5f630fc6ffd2f3dbeL90-R101)

These changes provide more flexible and accurate scheduling capabilities for project management workflows.…-resize functionality on the Gantt chart for both start and due dates.