### PR TITLE
Implement app-wide zoom with CSS variables and reactive effects

### DIFF
--- a/src/lib/hooks/app-zoom.svelte.ts
+++ b/src/lib/hooks/app-zoom.svelte.ts
@@ -3,42 +3,47 @@ import { browser } from "$app/environment";
 const ZOOM_KEY = "worklog:app-zoom";
 let globalZoom = $state(1);
 
+if (browser) {
+    const stored = localStorage.getItem(ZOOM_KEY);
+    if (stored) {
+        const parsed = parseFloat(stored);
+        if (!isNaN(parsed) && parsed >= 0.5 && parsed <= 2.0) {
+            globalZoom = parsed;
+        }
+    }
+
+    // Single reactive effect to handle both CSS variable and persistence
+    $effect.root(() => {
+        $effect(() => {
+            document.documentElement.style.setProperty("--app-zoom", globalZoom.toString());
+            localStorage.setItem(ZOOM_KEY, globalZoom.toString());
+        });
+    });
+}
+
 export function useAppZoom() {
     return {
         get zoom() {
             return globalZoom;
         },
         init() {
-            if (browser) {
-                const stored = localStorage.getItem(ZOOM_KEY);
-                if (stored) {
-                    const parsed = parseFloat(stored);
-                    if (!isNaN(parsed) && parsed >= 0.5 && parsed <= 2.0) {
-                        globalZoom = parsed;
-                    }
-                }
-            }
+            // No longer needed, logic moved to module level
         },
         zoomIn() {
             if (globalZoom < 2.0) {
                 globalZoom = Math.round((globalZoom + 0.1) * 10) / 10;
-                this.save();
             }
         },
         zoomOut() {
             if (globalZoom > 0.5) {
                 globalZoom = Math.round((globalZoom - 0.1) * 10) / 10;
-                this.save();
             }
         },
         reset() {
             globalZoom = 1;
-            this.save();
         },
         save() {
-            if (browser) {
-                localStorage.setItem(ZOOM_KEY, globalZoom.toString());
-            }
+            // No longer needed, handled by $effect
         }
     };
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,10 +27,6 @@
 	const appZoom = useAppZoom();
 	let hasInitializedWorkspace = $state(false);
 
-	$effect(() => {
-		appZoom.init();
-	});
-
 	// ── App-level callbacks ────────────────────────────────────────────────
 	function openSettings() {
 		void goto("/workspace/settings");
@@ -195,7 +191,7 @@
 
 <svelte:window onkeydown={onKeydown} />
 
-<div class="layout-shell" style="zoom: {appZoom.zoom}">
+<div class="layout-shell">
 	<AppToolbar
 		showSettings={workspace.status === "ready"}
 		onOpenSettings={openSettings}
@@ -222,16 +218,22 @@
 
 	:global(body) {
 		overflow: hidden;
+		transform: scale(var(--app-zoom, 1));
+		transform-origin: top left;
+		width: calc(100% / var(--app-zoom, 1)) !important;
+		height: calc(100% / var(--app-zoom, 1)) !important;
 	}
 
 	.layout-shell {
-		height: 100vh;
+		height: 100%;
+		display: flex;
+		flex-direction: column;
 	}
 
 	:global(.layout-content.bx--content) {
 		box-sizing: border-box;
 		min-height: 0;
-		height: calc(100vh - var(--cds-spacing-09, 3rem));
+		flex: 1;
 		overflow-x: hidden;
 		overflow-y: auto;
 	}


### PR DESCRIPTION
This pull request refactors how application-wide zoom is managed and applied. The main change is moving from inline zoom styles on the main container to a CSS variable (`--app-zoom`) that controls zoom via global CSS, with the zoom value now stored and updated reactively. This simplifies the zoom logic, centralizes side effects, and improves layout scaling.

**Zoom logic refactor and persistence:**

* Moved zoom initialization and persistence logic out of the `init` and `save` methods and into a single reactive `$effect` that updates both the CSS variable (`--app-zoom`) and `localStorage` whenever the zoom level changes. The `init` and `save` methods are now no-ops, as this is handled automatically. (`src/lib/hooks/app-zoom.svelte.ts`) [[1]](diffhunk://#diff-a81ddebe6b6c71846806c24b3304e996a236b052705decb24e0481cd37574fccL6-L11) [[2]](diffhunk://#diff-a81ddebe6b6c71846806c24b3304e996a236b052705decb24e0481cd37574fccR14-R46)
* Removed the call to `appZoom.init()` from the layout component, as initialization is now handled at the module level. (`src/routes/+layout.svelte`)

**CSS and layout improvements:**

* Replaced the inline `zoom` style on the `.layout-shell` container with global CSS that applies `transform: scale(var(--app-zoom))` to the `body`, along with adjustments to `width` and `height` to maintain proper scaling. (`src/routes/+layout.svelte`) [[1]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL198-R194) [[2]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR221-R236)
* Updated layout container styles to use flexbox and relative sizing, improving responsiveness and compatibility with the new zoom approach. (`src/routes/+layout.svelte`).