### PR TITLE
Implement TagManager component in ticket-add-edit-modal

### DIFF
--- a/src/lib/components/app/common/tag-manager.svelte
+++ b/src/lib/components/app/common/tag-manager.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+    import { Tag, TextInput, Button } from "carbon-components-svelte";
+    import { Add } from "carbon-icons-svelte";
+
+    let {
+        selectedTags = $bindable([]),
+        availableTags = [],
+        label = "Tags",
+    }: {
+        selectedTags: string[];
+        availableTags: string[];
+        label?: string;
+    } = $props();
+
+    let inputValue = $state("");
+    let isFocused = $state(false);
+
+    const filteredSuggestions = $derived(
+        availableTags
+            .filter((tag) => !selectedTags.includes(tag))
+            .filter((tag) =>
+                tag.toLowerCase().includes(inputValue.toLowerCase()),
+            ),
+    );
+
+    function addTag(tag: string) {
+        const cleanTag = tag.trim().toLowerCase();
+        if (cleanTag && !selectedTags.includes(cleanTag)) {
+            selectedTags = [...selectedTags, cleanTag];
+        }
+        inputValue = "";
+    }
+
+    function removeTag(tag: string) {
+        selectedTags = selectedTags.filter((t) => t !== tag);
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter" || e.key === ",") {
+            e.preventDefault();
+            e.stopPropagation();
+            addTag(inputValue);
+        } else if (
+            e.key === "Backspace" &&
+            inputValue === "" &&
+            selectedTags.length > 0
+        ) {
+            removeTag(selectedTags[selectedTags.length - 1]);
+        }
+    }
+</script>
+
+<div class="tag-manager">
+    <label class="tag-label" for="tag-input">{label}</label>
+
+    <div class="tag-input-container" class:focused={isFocused}>
+        <div class="selected-tags">
+            {#each selectedTags as tag}
+                <Tag type="cool-gray" filter on:close={() => removeTag(tag)}>
+                    {tag}
+                </Tag>
+            {/each}
+            <input
+                id="tag-input"
+                type="text"
+                placeholder={selectedTags.length === 0 ? "Add tags..." : ""}
+                bind:value={inputValue}
+                onkeydown={handleKeydown}
+                onfocus={() => (isFocused = true)}
+                onblur={() => setTimeout(() => (isFocused = false), 200)}
+            />
+        </div>
+
+        {#if isFocused && (filteredSuggestions.length > 0 || (inputValue.trim() && !selectedTags.includes(inputValue
+                            .trim()
+                            .toLowerCase())))}
+            <div class="suggestions-dropdown">
+                {#each filteredSuggestions as suggestion}
+                    <button
+                        type="button"
+                        class="suggestion-item"
+                        onclick={() => addTag(suggestion)}
+                    >
+                        {suggestion}
+                    </button>
+                {/each}
+                {#if inputValue.trim() && !availableTags.some((t) => t.toLowerCase() === inputValue
+                                .trim()
+                                .toLowerCase()) && !selectedTags.includes(inputValue
+                            .trim()
+                            .toLowerCase())}
+                    <button
+                        type="button"
+                        class="suggestion-item create-item"
+                        onclick={() => addTag(inputValue)}
+                    >
+                        <Add size={16} />
+                        <span>Create "{inputValue}"</span>
+                    </button>
+                {/if}
+            </div>
+        {/if}
+    </div>
+</div>
+
+<style>
+    .tag-manager {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        width: 100%;
+    }
+
+    .tag-label {
+        font-size: 0.75rem;
+        color: var(--cds-text-secondary, #525252);
+    }
+
+    .tag-input-container {
+        position: relative;
+        background-color: var(--cds-field-01, #f4f4f4);
+        border: 1px solid var(--cds-ui-04, #8d8d8d);
+        border-radius: 2px;
+        min-height: 2.5rem;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 0.25rem 0.5rem;
+        transition: all 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+    }
+
+    .tag-input-container:hover {
+        border-color: var(--cds-ui-05, #161616);
+    }
+
+    .tag-input-container.focused {
+        outline: 2px solid var(--cds-interactive-01, #0f62fe);
+        outline-offset: -1px;
+        border-color: transparent;
+    }
+
+    .selected-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+        align-items: center;
+        width: 100%;
+    }
+
+    .selected-tags input {
+        border: none;
+        background: transparent;
+        outline: none;
+        flex: 1;
+        min-width: 80px;
+        height: 2rem;
+        font-size: 0.875rem;
+        color: var(--cds-text-primary, #161616);
+    }
+
+    .suggestions-dropdown {
+        position: absolute;
+        bottom: 100%;
+        left: 0;
+        right: 0;
+        background: var(--cds-ui-01, #ffffff);
+        border: 1px solid var(--cds-ui-03, #e0e0e0);
+        box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.1);
+        z-index: 1000;
+        max-height: 200px;
+        overflow-y: auto;
+        margin-bottom: 2px;
+    }
+
+    .suggestion-item {
+        width: 100%;
+        text-align: left;
+        padding: 0.625rem 1rem;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        font-size: 0.875rem;
+        color: var(--cds-text-primary, #161616);
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .suggestion-item:hover {
+        background-color: var(--cds-ui-02, #f4f4f4);
+    }
+
+    .create-item {
+        border-top: 1px solid var(--cds-ui-03, #e0e0e0);
+        color: var(--cds-interactive-01, #0f62fe);
+        font-weight: 600;
+    }
+
+    :global(.tag-input-container .bx--tag) {
+        margin: 0;
+    }
+</style>

--- a/src/lib/components/app/kanban/ticket-add-edit-modal.svelte
+++ b/src/lib/components/app/kanban/ticket-add-edit-modal.svelte
@@ -4,10 +4,10 @@
         TextInput,
         TextArea,
         Dropdown,
-        MultiSelect,
         DatePicker,
         DatePickerInput,
     } from "carbon-components-svelte";
+    import TagManager from "../common/tag-manager.svelte";
     import { untrack } from "svelte";
     import {
         type Ticket,
@@ -186,7 +186,7 @@
         {#if error}
             <p class="modal-error">{error}</p>
         {/if}
-        
+
         <div class="form-main">
             <TextInput
                 labelText="Title *"
@@ -244,10 +244,10 @@
                 </DatePicker>
             </div>
             <div class="attribute-full">
-                <MultiSelect
-                    label="Select tags…"
-                    items={TAG_OPTIONS.map((t) => ({ id: t, text: t }))}
-                    bind:selectedIds={form.tags}
+                <TagManager
+                    label="Tags"
+                    availableTags={TAG_OPTIONS}
+                    bind:selectedTags={form.tags}
                 />
             </div>
         </div>
@@ -270,21 +270,21 @@
     .modal-form {
         display: flex;
         flex-direction: column;
-        gap: 2rem;
-        padding-block: 1rem;
+        gap: 1.25rem;
+        padding-block: 0.5rem;
     }
 
     .form-main {
         display: flex;
         flex-direction: column;
-        gap: 1.5rem;
+        gap: 1rem;
     }
 
     .form-attributes {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        gap: 1.5rem;
-        padding-top: 1.5rem;
+        gap: 1rem;
+        padding-top: 1rem;
         border-top: 1px solid var(--cds-ui-03);
     }
 


### PR DESCRIPTION
This pull request introduces a new `TagManager` component to improve the user experience for managing tags in the ticket add/edit modal. The new component provides a more intuitive and interactive way to select, create, and remove tags, replacing the previous `MultiSelect` dropdown. Additionally, some layout adjustments were made to the modal for a cleaner appearance.

**Tag management improvements:**

* Added a new `TagManager` component (`tag-manager.svelte`) that allows users to add, remove, and create tags with type-ahead suggestions and keyboard support.
* Replaced the `MultiSelect` dropdown with the new `TagManager` in the ticket add/edit modal, providing a more user-friendly interface for tag selection and creation. [[1]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffL7-R10) [[2]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffL247-R250)

**UI/UX adjustments:**

* Updated spacing and padding in the modal form and its sections to improve layout and visual clarity.

# Demonstration : 

[Kooha-2026-05-04-01-20-10.webm](https://github.com/user-attachments/assets/2fdf88d5-4d91-467c-bc35-3a3f9b456e66)
