### PR TITLE
Add global scrollbar styling and board-specific state restoration

### DIFF
--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -19,3 +19,33 @@ body {
   -ms-user-select: none;     /* IE11/Edge */
   user-select: none;         /* Standard */
 }
+
+/* ── Custom Scrollbar (VS Code style) ────────────────────────────────── */
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: rgba(136, 136, 136, 0.4);
+  border-radius: 0px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(136, 136, 136, 0.6);
+}
+
+*::-webkit-scrollbar-thumb:active {
+  background-color: rgba(136, 136, 136, 0.8);
+}
+
+/* Firefox support */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(136, 136, 136, 0.4) transparent;
+}
+

--- a/src/routes/workspace/+page.svelte
+++ b/src/routes/workspace/+page.svelte
@@ -12,12 +12,16 @@
             return;
         }
 
-        const firstBoard = boardsApi.boards[0];
-        if (!firstBoard) {
+        const lastBoardId = localStorage.getItem("worklog:last_board_id");
+        const boardToOpen = lastBoardId 
+            ? boardsApi.boards.find(b => b.id === lastBoardId) || boardsApi.boards[0]
+            : boardsApi.boards[0];
+
+        if (!boardToOpen) {
             return;
         }
 
-        void goto(`/workspace/${firstBoard.id}`, { replaceState: true });
+        void goto(`/workspace/${boardToOpen.id}`, { replaceState: true });
     });
 </script>
 

--- a/src/routes/workspace/[board_id]/+page.svelte
+++ b/src/routes/workspace/[board_id]/+page.svelte
@@ -21,16 +21,43 @@
         void goto("/workspace");
     }
 
+    let selectedTab = $state(0);
+    let lastRestoredBoardId = $state<string | null>(null);
+
     $effect(() => {
         if (!board) {
             return;
         }
+
+        // Save last board ID globally
+        localStorage.setItem("worklog:last_board_id", board.id);
 
         if (boardsApi.active?.id === board.id) {
             return;
         }
 
         boardsApi.setActive(board);
+    });
+
+    // Save/Restore tab index (Board-specific)
+    $effect(() => {
+        if (!board) return;
+
+        if (lastRestoredBoardId !== board.id) {
+            const saved = localStorage.getItem(`worklog:last_tab_index:${board.id}`);
+            if (saved !== null) {
+                selectedTab = parseInt(saved, 10);
+            } else {
+                // Global fallback or default to Kanban (0)
+                const globalSaved = localStorage.getItem("worklog:last_tab_index");
+                selectedTab = globalSaved !== null ? parseInt(globalSaved, 10) : 0;
+            }
+            lastRestoredBoardId = board.id;
+        } else {
+            // Save both board-specific and global preference
+            localStorage.setItem(`worklog:last_tab_index:${board.id}`, selectedTab.toString());
+            localStorage.setItem("worklog:last_tab_index", selectedTab.toString());
+        }
     });
 </script>
 
@@ -55,7 +82,7 @@
         </header>
 
         <section class="workspace-board-content" aria-label="Board content">
-            <Tabs autoWidth>
+            <Tabs autoWidth bind:selected={selectedTab}>
                 <Tab label="Board" icon={Dashboard} />
                 <Tab label="Table" icon={Table} />
                 <Tab label="Timeline" icon={ChartBarFloating} />

--- a/src/routes/workspace/settings/+page.svelte
+++ b/src/routes/workspace/settings/+page.svelte
@@ -973,21 +973,4 @@
         color: var(--cds-text-helper);
         margin: 0;
     }
-
-    /* Custom scrollbar */
-    .content-body::-webkit-scrollbar {
-        width: 10px;
-    }
-    .content-body::-webkit-scrollbar-track {
-        background: transparent;
-    }
-    .content-body::-webkit-scrollbar-thumb {
-        background: var(--cds-ui-03);
-        border: 2px solid transparent;
-        background-clip: padding-box;
-        border-radius: 10px;
-    }
-    .content-body::-webkit-scrollbar-thumb:hover {
-        background: var(--cds-ui-04);
-    }
 </style>


### PR DESCRIPTION
This pull request introduces improvements to user experience by enhancing persistence of user preferences (such as last opened board and tab selection) in the workspace, and by unifying the appearance of scrollbars throughout the app with a custom VS Code-style design. It also removes redundant, page-specific scrollbar styles now made obsolete by the global style.

**User Preference Persistence**

* The workspace will now automatically open the last board the user visited, using the `worklog:last_board_id` value stored in `localStorage`. If not present, it falls back to the first available board. (`src/routes/workspace/+page.svelte`)
* The selected tab index for each board is now saved and restored per board using `localStorage`, with a global fallback. This ensures users return to the same view (e.g., Board, Table, Timeline) when switching boards or revisiting the workspace. (`src/routes/workspace/[board_id]/+page.svelte`) ([src/routes/workspace/[board_id]/+page.svelteR24-R61](diffhunk://#diff-e3585284f111689962fa833375d61c0a395bf8426e97ca66085f91df0e01165cR24-R61), [src/routes/workspace/[board_id]/+page.svelteL58-R85](diffhunk://#diff-e3585284f111689962fa833375d61c0a395bf8426e97ca66085f91df0e01165cL58-R85))

**UI Consistency and Cleanup**

* Introduced a global, VS Code-style custom scrollbar across the app for both Webkit and Firefox browsers, improving visual consistency. (`src/routes/layout.css`)
* Removed the now-redundant custom scrollbar styles from the workspace settings page, relying instead on the new global scrollbar style. (`src/routes/workspace/settings/+page.svelte`)

**Submodule Update**

* Updated the `aur` submodule to a new commit, which may bring in upstream changes or bugfixes. (`aur`)