### PR TITLE
Implement dynamic ticket types management with UI and schema support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worklog",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6050,7 +6050,7 @@ dependencies = [
 
 [[package]]
 name = "worklog"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worklog"
-version = "1.2.3"
+version = "1.2.4"
 description = "Local-first desktop project manager for small development teams"
 authors = ["Ezzoubair ZARQI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "worklog",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "plugins": {
     "fs": {
       "requireLiteralLeadingDot": false

--- a/src/lib/components/app/gantt/gantt-board.svelte
+++ b/src/lib/components/app/gantt/gantt-board.svelte
@@ -17,12 +17,13 @@
     import TicketDeleteConfirm from "../kanban/ticket-delete-confirm.svelte";
 
     const shell = getWorkspaceShellContext();
+    const { ticketTypesApi } = shell;
     const getWorkspacePath = () => shell.workspace.path;
     const getBoardId = () => shell.boardsApi.active?.id ?? null;
     const ticketsHook = useTickets(getWorkspacePath, getBoardId);
 
     // Initialize State Context
-    const gantt = new GanttState(ticketsHook);
+    const gantt = new GanttState(ticketsHook, ticketTypesApi);
     setGanttState(gantt);
 
     // Auto-scroll to today on mount

--- a/src/lib/components/app/gantt/gantt-state.svelte.ts
+++ b/src/lib/components/app/gantt/gantt-state.svelte.ts
@@ -42,6 +42,7 @@ export class GanttState {
     GROUP_H = 32;
 
     #ticketsHook: any;
+    #ticketTypesApi: any;
     #sortHook = useTicketSort();
 
     searchQuery = $state("");
@@ -57,8 +58,9 @@ export class GanttState {
 
     dragTicketId = $state<string | null>(null);
 
-    constructor(ticketsHook: any) {
+    constructor(ticketsHook: any, ticketTypesApi: any) {
         this.#ticketsHook = ticketsHook;
+        this.#ticketTypesApi = ticketTypesApi;
     }
 
     get filteredTickets(): Ticket[] {
@@ -169,7 +171,8 @@ export class GanttState {
         for (const g of this.groupedTickets) {
             rows.push({ kind: "group", status: g.status, label: g.label, color: g.color, icon: g.icon, count: g.tickets.length });
             for (const t of g.tickets) {
-                rows.push({ kind: "ticket", ticket: t, color: g.color });
+                const customType = this.#ticketTypesApi.types.find((tt: any) => tt.id === t.ticket_type);
+                rows.push({ kind: "ticket", ticket: t, color: customType?.color || g.color });
             }
         }
         return rows;

--- a/src/lib/components/app/gantt/gantt-tooltip.svelte
+++ b/src/lib/components/app/gantt/gantt-tooltip.svelte
@@ -7,10 +7,17 @@
         TICKET_PRIORITY_CONFIG,
     } from "$lib/components/app/types";
 
+    import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
+
     const state = getGanttState();
+    const context = getWorkspaceShellContext();
+    const ticketTypesApi = context?.ticketTypesApi;
 </script>
 
 {#if state.hoveredTicket}
+    {@const customType = ticketTypesApi?.types?.find(
+        (t) => t.id === state.hoveredTicket?.ticket_type,
+    )}
     <div
         class="gantt-tip"
         style="left:{state.tooltipX + 14}px;top:{state.tooltipY - 8}px"
@@ -23,12 +30,28 @@
             >
         </div>
         <div class="tip-row">
-            <span class="tip-label">Priority</span>
+            <span class="tip-label">Type</span>
             <Tag
-                type={TICKET_PRIORITY_CONFIG[state.hoveredTicket.priority as keyof typeof TICKET_PRIORITY_CONFIG]?.tagColor || "blue"}
+                style="background-color: {customType?.color ||
+                    '#525252'}; color: white;"
                 size="sm"
             >
-                {TICKET_PRIORITY_CONFIG[state.hoveredTicket.priority as keyof typeof TICKET_PRIORITY_CONFIG]?.label}
+                {customType?.name || state.hoveredTicket.ticket_type}
+            </Tag>
+        </div>
+        <div class="tip-row">
+            <span class="tip-label">Priority</span>
+            <Tag
+                type={TICKET_PRIORITY_CONFIG[
+                    state.hoveredTicket
+                        .priority as keyof typeof TICKET_PRIORITY_CONFIG
+                ]?.tagColor || "blue"}
+                size="sm"
+            >
+                {TICKET_PRIORITY_CONFIG[
+                    state.hoveredTicket
+                        .priority as keyof typeof TICKET_PRIORITY_CONFIG
+                ]?.label}
             </Tag>
         </div>
         <div class="tip-row">
@@ -44,10 +67,13 @@
                 <Calendar size={12} />
                 <span class="tip-label">Start</span>
                 <span class="tip-val"
-                    >{new Date(state.hoveredTicket.start_date).toLocaleDateString(
-                        "en-US",
-                        { month: "short", day: "numeric", year: "numeric" },
-                    )}</span
+                    >{new Date(
+                        state.hoveredTicket.start_date,
+                    ).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                    })}</span
                 >
             </div>
         {/if}

--- a/src/lib/components/app/kanban/kanban-ticket-card.svelte
+++ b/src/lib/components/app/kanban/kanban-ticket-card.svelte
@@ -40,6 +40,8 @@
         TICKET_PRIORITY_CONFIG,
     } from "$lib/components/app/types";
 
+    import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
+
     let {
         ticket,
         onEdit,
@@ -52,8 +54,11 @@
         onStatusChange?: (id: string, status: TicketStatus) => void;
     } = $props();
 
-    // Carbon icon map for ticket types
-    const typeIconMap: Record<TicketType, any> = {
+    const context = getWorkspaceShellContext();
+    const ticketTypesApi = context?.ticketTypesApi;
+
+    // Carbon icon map for fallback/default icons
+    const typeIconMap: Record<string, any> = {
         feature: StarFilled,
         bug: Debug,
         chore: SettingsAdjust,
@@ -75,8 +80,21 @@
         p3: ArrowDown,
     };
 
-    const typeConfig = $derived(TICKET_TYPE_CONFIG[ticket.ticket_type]);
-    const TypeIcon = $derived(typeIconMap[ticket.ticket_type]);
+    const customType = $derived(
+        ticketTypesApi?.types?.find((t) => t.id === ticket.ticket_type)
+    );
+
+    const typeConfig = $derived({
+        label: customType?.name ?? ticket.ticket_type,
+        color: customType?.color ?? "#525252",
+    });
+
+    const TypeIcon = $derived(
+        (customType?.icon && typeIconMap[customType.icon]) || 
+        typeIconMap[ticket.ticket_type] || 
+        Bookmark
+    );
+
     const priorityConfig = $derived(TICKET_PRIORITY_CONFIG[ticket.priority]);
     const PriorityIcon = $derived(priorityIconMap[ticket.priority]);
 
@@ -200,7 +218,10 @@
                         {priorityConfig.label}
                     </span>
                 </Tag>
-                <Tag size="sm" type={typeConfig.tagColor}>
+                <Tag 
+                    size="sm" 
+                    style="background-color: {typeConfig.color}; color: white;"
+                >
                     <span class="tag-with-icon">
                         <TypeIcon size={12} />
                         {typeConfig.label}

--- a/src/lib/components/app/kanban/ticket-add-edit-modal.svelte
+++ b/src/lib/components/app/kanban/ticket-add-edit-modal.svelte
@@ -18,6 +18,8 @@
         TICKET_TYPE_OPTIONS,
     } from "$lib/components/app/types";
 
+    import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
+
     let {
         open = $bindable(false),
         ticket = null,
@@ -32,13 +34,15 @@
             title: string;
             description: string;
             priority: TicketPriority;
-            ticketType: TicketType;
+            ticketType: string;
             startDate: string;
             dueDate: string;
             tags: string[];
             status: TicketStatus;
         }) => Promise<void>;
     } = $props();
+
+    const { ticketTypesApi } = getWorkspaceShellContext();
 
     const isEditing = $derived(!!ticket);
 
@@ -50,7 +54,7 @@
         title: string;
         description: string;
         priority: TicketPriority;
-        ticketType: TicketType;
+        ticketType: string;
         startDate: string;
         dueDate: string;
         tags: string[];
@@ -107,11 +111,12 @@
                         tags: ticket.labels ?? [],
                     };
                 } else {
+                    const defaultType = ticketTypesApi.types.find(t => t.is_default) || ticketTypesApi.types[0];
                     form = {
                         title: "",
                         description: "",
                         priority: "p2",
-                        ticketType: "feature",
+                        ticketType: defaultType?.id || "feature",
                         startDate: "",
                         dueDate: "",
                         tags: [],
@@ -215,9 +220,9 @@
                 <Dropdown
                     labelText="Type"
                     bind:selectedId={form.ticketType}
-                    items={TICKET_TYPE_OPTIONS.map((typeKey) => ({
-                        id: typeKey,
-                        text: TICKET_TYPE_CONFIG[typeKey].label,
+                    items={ticketTypesApi.types.map((t) => ({
+                        id: t.id,
+                        text: t.name,
                     }))}
                 />
             </div>

--- a/src/lib/components/app/table/table-group.svelte
+++ b/src/lib/components/app/table/table-group.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
-    import { DataTable, Tag, OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
-    import { Calendar } from "carbon-icons-svelte";
-    import { getTableState, priorityIconMap, typeIconMap } from "./table-state.svelte";
+    import {
+        DataTable,
+        Tag,
+        OverflowMenu,
+        OverflowMenuItem,
+    } from "carbon-components-svelte";
+    import { Calendar, Bookmark } from "carbon-icons-svelte";
+    import {
+        getTableState,
+        priorityIconMap,
+        typeIconMap,
+    } from "./table-state.svelte";
+    import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
     import {
         TICKET_PRIORITY_CONFIG,
-        TICKET_TYPE_CONFIG,
         type TicketPriority,
         type TicketType,
     } from "$lib/components/app/types";
+
+    const context = getWorkspaceShellContext();
+    const ticketTypesApi = context?.ticketTypesApi;
 
     const state = getTableState();
 
@@ -65,62 +77,97 @@
                     <svelte:fragment slot="cell" let:row let:cell>
                         {#if cell.key === "title"}
                             <div class="cell-title">
-                                <span class="cell-title-text">{cell.value}</span>
+                                <span class="cell-title-text">{cell.value}</span
+                                >
                                 <span class="cell-title-id">{row.id}</span>
                             </div>
                         {:else if cell.key === "priority"}
-                            {@const PriorityIcon = priorityIconMap[cell.value as TicketPriority]}
+                            {@const PriorityIcon =
+                                priorityIconMap[cell.value as TicketPriority]}
                             <div class="cell-priority">
                                 {#if PriorityIcon}
                                     <PriorityIcon size={14} />
                                 {/if}
                                 <Tag
-                                    type={TICKET_PRIORITY_CONFIG[cell.value as TicketPriority]?.tagColor || "blue"}
+                                    type={TICKET_PRIORITY_CONFIG[
+                                        cell.value as TicketPriority
+                                    ]?.tagColor || "blue"}
                                     size="sm"
                                 >
-                                    {TICKET_PRIORITY_CONFIG[cell.value as TicketPriority]?.label || cell.value}
+                                    {TICKET_PRIORITY_CONFIG[
+                                        cell.value as TicketPriority
+                                    ]?.label || cell.value}
                                 </Tag>
                             </div>
                         {:else if cell.key === "type"}
-                            {@const TypeIcon = typeIconMap[cell.value as TicketType]}
+                            {@const customType = ticketTypesApi?.types?.find(
+                                (t) => t.id === cell.value,
+                            )}
+                            {@const TypeIcon =
+                                (customType?.icon &&
+                                    typeIconMap[
+                                        customType.icon as TicketType
+                                    ]) ||
+                                typeIconMap[cell.value as TicketType] ||
+                                Bookmark}
                             <div class="cell-type">
                                 {#if TypeIcon}
                                     <TypeIcon size={14} />
                                 {/if}
                                 <Tag
-                                    type={TICKET_TYPE_CONFIG[cell.value as TicketType]?.tagColor || "blue"}
+                                    style="background-color: {customType?.color ||
+                                        '#525252'}; color: white;"
                                     size="sm"
                                 >
-                                    {TICKET_TYPE_CONFIG[cell.value as TicketType]?.label || cell.value}
+                                    {customType?.name || cell.value}
                                 </Tag>
                             </div>
                         {:else if cell.key === "labels"}
                             <div class="cell-labels">
                                 {#if Array.isArray(cell.value) && cell.value.length > 0}
                                     {#each cell.value.slice(0, 3) as label}
-                                        <Tag type="outline" size="sm">{label}</Tag>
+                                        <Tag type="outline" size="sm"
+                                            >{label}</Tag
+                                        >
                                     {/each}
                                     {#if cell.value.length > 3}
-                                        <span class="labels-more">+{cell.value.length - 3}</span>
+                                        <span class="labels-more"
+                                            >+{cell.value.length - 3}</span
+                                        >
                                     {/if}
                                 {:else}
                                     <span class="cell-muted">—</span>
                                 {/if}
                             </div>
                         {:else if cell.key === "dueDate"}
-                            {@const due = state.formatDueDate(cell.value, row.status === "done")}
+                            {@const due = state.formatDueDate(
+                                cell.value,
+                                row.status === "done",
+                            )}
                             <div class="cell-due" class:overdue={due.overdue}>
                                 <Calendar size={14} />
                                 <span>{due.text}</span>
                             </div>
                         {:else if cell.key === "created"}
-                            <span class="cell-date">{state.formatRelativeDate(cell.value)}</span>
+                            <span class="cell-date"
+                                >{state.formatRelativeDate(cell.value)}</span
+                            >
                         {:else if cell.key === "actions"}
                             <div class="cell-actions">
                                 <OverflowMenu flipped size="sm">
-                                    <OverflowMenuItem text="Copy ID" on:click={() => copyId(row.id)} />
-                                    <OverflowMenuItem text="Edit ticket" on:click={() => onEdit(row.id)} />
-                                    <OverflowMenuItem danger text="Delete" on:click={() => onDelete(row.id)} />
+                                    <OverflowMenuItem
+                                        text="Copy ID"
+                                        on:click={() => copyId(row.id)}
+                                    />
+                                    <OverflowMenuItem
+                                        text="Edit ticket"
+                                        on:click={() => onEdit(row.id)}
+                                    />
+                                    <OverflowMenuItem
+                                        danger
+                                        text="Delete"
+                                        on:click={() => onDelete(row.id)}
+                                    />
                                 </OverflowMenu>
                             </div>
                         {:else}
@@ -249,7 +296,8 @@
     }
 
     .group-table-wrapper :global(.bx--data-table td) {
-        border-bottom: 1px solid color-mix(in srgb, var(--cds-ui-03) 50%, transparent);
+        border-bottom: 1px solid
+            color-mix(in srgb, var(--cds-ui-03) 50%, transparent);
         padding-top: 0.5rem;
         padding-bottom: 0.5rem;
         vertical-align: middle;

--- a/src/lib/db/connection.ts
+++ b/src/lib/db/connection.ts
@@ -25,6 +25,31 @@ export async function getDb(workspacePath: string): Promise<Database> {
     _db = await Database.load(`sqlite:${workspacePath}/.worklog/worklog.db`);
     _dbWorkspacePath = workspacePath;
     await _db.execute(CREATE_TABLES);
+
+    // ── Handle Migrations ──────────────────────────────
+    const { runMigrations } = await import('./migrate');
+    await runMigrations(_db);
+
+    // ── Seed Default Ticket Types if empty ──────────────
+    const typesCount = await _db.select<{ count: number }[]>("SELECT COUNT(*) as count FROM ticket_types");
+    if (typesCount && typesCount[0] && typesCount[0].count === 0) {
+        const now = new Date().toISOString();
+        const defaultTypes = [
+            { id: 'bug', name: 'Bug', color: '#fa4d56', icon: 'bug', is_default: 0 },
+            { id: 'feature', name: 'Feature', color: '#198038', icon: 'star', is_default: 1 },
+            { id: 'chore', name: 'Chore', color: '#525252', icon: 'tools', is_default: 0 },
+            { id: 'task', name: 'Task', color: '#00539a', icon: 'checkmark', is_default: 0 },
+            { id: 'improvement', name: 'Improvement', color: '#8a3ffc', icon: 'upgrade', is_default: 0 },
+        ];
+
+        for (const t of defaultTypes) {
+            await _db.execute(
+                "INSERT INTO ticket_types (id, name, color, icon, is_default, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [t.id, t.name, t.color, t.icon, t.is_default, now, now]
+            );
+        }
+    }
+
     return _db;
 }
 

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -2,4 +2,5 @@ export { getDb, closeDb } from './connection';
 export * as WorkspaceRepo from './repositories/workspace.repo';
 export * as BoardRepo from './repositories/board.repo';
 export * as TicketRepo from './repositories/ticket.repo';
+export * as TicketTypeRepo from './repositories/ticket-type.repo';
 export * as SettingsRepo from './repositories/settings.repo';

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -340,6 +340,82 @@ async function migrate_v11(db: Database) {
     }
 }
 
+/**
+ * Migration v12:
+ * Create ticket_types table and recreate tickets table without ticket_type CHECK constraint.
+ */
+async function migrate_v12(db: Database) {
+    // 1. Create ticket_types table
+    await db.execute(`
+        CREATE TABLE IF NOT EXISTS ticket_types (
+            id          TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            color       TEXT NOT NULL,
+            icon        TEXT,
+            is_default  INTEGER NOT NULL DEFAULT 0,
+            created_at  TEXT NOT NULL,
+            updated_at  TEXT NOT NULL
+        )
+    `);
+
+    // 2. Recreate tickets table without ticket_type CHECK constraint
+    await db.execute(`PRAGMA foreign_keys = OFF`);
+    await db.execute(`BEGIN TRANSACTION`);
+
+    try {
+        await db.execute(`ALTER TABLE tickets RENAME TO tickets_v11`);
+
+        await db.execute(`
+            CREATE TABLE tickets (
+                id          TEXT PRIMARY KEY,
+                board_id    TEXT NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+                title       TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                status      TEXT NOT NULL DEFAULT 'todo'
+                            CHECK (status IN ('backlog', 'todo', 'in_progress', 'done')),
+                priority    TEXT NOT NULL DEFAULT 'p2'
+                            CHECK (priority IN ('p1', 'p2', 'p3')),
+                ticket_type TEXT NOT NULL DEFAULT 'feature',
+                position    REAL NOT NULL DEFAULT 0,
+                due_date    TEXT,
+                start_date  TEXT,
+                labels      TEXT NOT NULL DEFAULT '[]',
+                comments    TEXT NOT NULL DEFAULT '[]',
+                created_at  TEXT NOT NULL,
+                updated_at  TEXT NOT NULL
+            )
+        `);
+
+        await db.execute(`
+            INSERT INTO tickets (
+                id, board_id, title, description,
+                status, priority, ticket_type, position, due_date, start_date,
+                labels, comments, created_at, updated_at
+            )
+            SELECT
+                id, board_id, title, description,
+                status, priority, ticket_type, position, due_date, start_date,
+                labels, comments, created_at, updated_at
+            FROM tickets_v11
+        `);
+
+        await db.execute(`DROP TABLE tickets_v11`);
+        await db.execute(`CREATE INDEX IF NOT EXISTS idx_tickets_board_id ON tickets(board_id)`);
+        await db.execute(`CREATE INDEX IF NOT EXISTS idx_tickets_status ON tickets(status)`);
+        await db.execute(`CREATE INDEX IF NOT EXISTS idx_tickets_priority ON tickets(priority)`);
+        await db.execute(`CREATE INDEX IF NOT EXISTS idx_tickets_ticket_type ON tickets(ticket_type)`);
+        await db.execute(`CREATE INDEX IF NOT EXISTS idx_tickets_due_date ON tickets(due_date)`);
+        await db.execute(`CREATE INDEX IF NOT EXISTS idx_tickets_position ON tickets(position)`);
+
+        await db.execute(`COMMIT`);
+    } catch (error) {
+        await db.execute(`ROLLBACK`);
+        throw error;
+    } finally {
+        await db.execute(`PRAGMA foreign_keys = ON`);
+    }
+}
+
 
 export async function runMigrations(db: Database): Promise<void> {
     const rows = await db.select<{ schema_version: number }[]>(
@@ -388,6 +464,10 @@ export async function runMigrations(db: Database): Promise<void> {
 
     if (current < 11) {
         await migrate_v11(db);
+    }
+
+    if (current < 12) {
+        await migrate_v12(db);
     }
 
     await db.execute(

--- a/src/lib/db/repositories/ticket-type.repo.ts
+++ b/src/lib/db/repositories/ticket-type.repo.ts
@@ -1,0 +1,84 @@
+import type Database from "@tauri-apps/plugin-sql";
+
+export interface TicketType {
+    id: string;
+    name: string;
+    color: string;
+    icon: string | null;
+    is_default: boolean;
+    created_at: string;
+    updated_at: string;
+}
+
+export async function getAll(db: Database): Promise<TicketType[]> {
+    const rows = await db.select<any[]>(
+        "SELECT * FROM ticket_types ORDER BY name ASC"
+    );
+    return rows.map(mapRow);
+}
+
+export async function getById(db: Database, id: string): Promise<TicketType | null> {
+    const rows = await db.select<any[]>(
+        "SELECT * FROM ticket_types WHERE id = ?",
+        [id]
+    );
+    return rows.length > 0 ? mapRow(rows[0]) : null;
+}
+
+export async function getDefault(db: Database): Promise<TicketType | null> {
+    const rows = await db.select<any[]>(
+        "SELECT * FROM ticket_types WHERE is_default = 1 LIMIT 1"
+    );
+    return rows.length > 0 ? mapRow(rows[0]) : null;
+}
+
+export async function create(db: Database, type: Partial<TicketType>): Promise<void> {
+    const now = new Date().toISOString();
+    const id = type.id || crypto.randomUUID();
+    
+    // If setting as default, unset others
+    if (type.is_default) {
+        await db.execute("UPDATE ticket_types SET is_default = 0");
+    }
+
+    await db.execute(
+        "INSERT INTO ticket_types (id, name, color, icon, is_default, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [id, type.name, type.color, type.icon, type.is_default ? 1 : 0, now, now]
+    );
+}
+
+export async function update(db: Database, id: string, type: Partial<TicketType>): Promise<void> {
+    const now = new Date().toISOString();
+    
+    if (type.is_default) {
+        await db.execute("UPDATE ticket_types SET is_default = 0");
+    }
+
+    const fields: string[] = [];
+    const values: any[] = [];
+
+    if (type.name !== undefined) { fields.push("name = ?"); values.push(type.name); }
+    if (type.color !== undefined) { fields.push("color = ?"); values.push(type.color); }
+    if (type.icon !== undefined) { fields.push("icon = ?"); values.push(type.icon); }
+    if (type.is_default !== undefined) { fields.push("is_default = ?"); values.push(type.is_default ? 1 : 0); }
+    
+    fields.push("updated_at = ?");
+    values.push(now);
+    values.push(id);
+
+    await db.execute(
+        `UPDATE ticket_types SET ${fields.join(", ")} WHERE id = ?`,
+        values
+    );
+}
+
+export async function remove(db: Database, id: string): Promise<void> {
+    await db.execute("DELETE FROM ticket_types WHERE id = ?", [id]);
+}
+
+function mapRow(row: any): TicketType {
+    return {
+        ...row,
+        is_default: row.is_default === 1
+    };
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 11;
+export const SCHEMA_VERSION = 12;
 
 export const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS workspace_meta (
@@ -17,6 +17,16 @@ export const CREATE_TABLES = `
     updated_at  TEXT NOT NULL
   );
 
+  CREATE TABLE IF NOT EXISTS ticket_types (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    color       TEXT NOT NULL,
+    icon        TEXT,
+    is_default  INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+  );
+
   CREATE TABLE IF NOT EXISTS tickets (
     id          TEXT PRIMARY KEY,
     board_id    TEXT NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
@@ -26,8 +36,7 @@ export const CREATE_TABLES = `
                 CHECK (status IN ('backlog', 'todo', 'in_progress', 'done')),
     priority    TEXT NOT NULL DEFAULT 'p2'
                 CHECK (priority IN ('p1', 'p2', 'p3')),
-    ticket_type TEXT NOT NULL DEFAULT 'feature'
-                CHECK (ticket_type IN ('feature', 'bug', 'chore', 'improvement', 'epic', 'spike', 'story', 'task', 'subtask', 'incident', 'design', 'documentation')),
+    ticket_type TEXT NOT NULL DEFAULT 'feature',
     position    REAL NOT NULL DEFAULT 0,
     due_date    TEXT,
     start_date  TEXT,
@@ -64,4 +73,5 @@ export const CREATE_TABLES = `
   CREATE INDEX IF NOT EXISTS idx_tickets_priority ON tickets(priority);
   CREATE INDEX IF NOT EXISTS idx_tickets_ticket_type ON tickets(ticket_type);
   CREATE INDEX IF NOT EXISTS idx_tickets_due_date ON tickets(due_date);
+  CREATE INDEX IF NOT EXISTS idx_ticket_types_is_default ON ticket_types(is_default);
 `;

--- a/src/lib/hooks/ticket-types.svelte.ts
+++ b/src/lib/hooks/ticket-types.svelte.ts
@@ -1,0 +1,58 @@
+import { getDb } from "$lib/db";
+import { TicketTypeRepo } from "$lib/db";
+import type { TicketType } from "$lib/db/repositories/ticket-type.repo";
+
+export function useTicketTypes(workspacePath: () => string | null) {
+    let types = $state<TicketType[]>([]);
+    let loading = $state(false);
+    let error = $state<string | null>(null);
+
+    async function load() {
+        const path = workspacePath();
+        if (!path) return;
+
+        loading = true;
+        try {
+            const db = await getDb(path);
+            types = await TicketTypeRepo.getAll(db);
+        } catch (e) {
+            error = String(e);
+        } finally {
+            loading = false;
+        }
+    }
+
+    async function create(type: Partial<TicketType>) {
+        const path = workspacePath();
+        if (!path) return;
+        const db = await getDb(path);
+        await TicketTypeRepo.create(db, type);
+        await load();
+    }
+
+    async function update(id: string, type: Partial<TicketType>) {
+        const path = workspacePath();
+        if (!path) return;
+        const db = await getDb(path);
+        await TicketTypeRepo.update(db, id, type);
+        await load();
+    }
+
+    async function remove(id: string) {
+        const path = workspacePath();
+        if (!path) return;
+        const db = await getDb(path);
+        await TicketTypeRepo.remove(db, id);
+        await load();
+    }
+
+    return {
+        get types() { return types; },
+        get loading() { return loading; },
+        get error() { return error; },
+        load,
+        create,
+        update,
+        remove
+    };
+}

--- a/src/lib/hooks/workspace-shell-context.ts
+++ b/src/lib/hooks/workspace-shell-context.ts
@@ -2,13 +2,16 @@ import { createContext } from "svelte";
 
 import type { useBoards } from "$lib/hooks/boards.svelte";
 import type { useWorkspace } from "$lib/hooks/workspace.svelte";
+import type { useTicketTypes } from "$lib/hooks/ticket-types.svelte";
 
 export type WorkspaceApi = ReturnType<typeof useWorkspace>;
 export type BoardsApi = ReturnType<typeof useBoards>;
+export type TicketTypesApi = ReturnType<typeof useTicketTypes>;
 
 export interface WorkspaceShellContext {
     workspace: WorkspaceApi;
     boardsApi: BoardsApi;
+    ticketTypesApi: TicketTypesApi;
 }
 
 export const [getWorkspaceShellContext, setWorkspaceShellContext] =

--- a/src/routes/workspace/+layout.svelte
+++ b/src/routes/workspace/+layout.svelte
@@ -5,6 +5,7 @@
 
     import WorkspaceSidebar from "$lib/components/app/layout/workspace/workspace-sidebar.svelte";
     import { useBoards } from "$lib/hooks/boards.svelte";
+    import { useTicketTypes } from "$lib/hooks/ticket-types.svelte";
     import { setWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
     import { useWorkspace } from "$lib/hooks/workspace.svelte";
     import { useCommandPalette } from "$lib/hooks/command-palette.svelte";
@@ -16,9 +17,10 @@
     let { children } = $props();
     const workspace = useWorkspace();
     const boardsApi = useBoards(() => workspace.path);
+    const ticketTypesApi = useTicketTypes(() => workspace.path);
     const palette = useCommandPalette();
 
-    setWorkspaceShellContext({ workspace, boardsApi });
+    setWorkspaceShellContext({ workspace, boardsApi, ticketTypesApi });
 
     let lastLoadedWorkspacePath = $state<string | null>(null);
     let boardLoadError = $state<string | null>(null);
@@ -55,7 +57,10 @@
         lastLoadedWorkspacePath = workspacePath;
         boardLoadError = null;
 
-        void boardsApi.load().catch((error) => {
+        void Promise.all([
+            boardsApi.load(),
+            ticketTypesApi.load()
+        ]).catch((error) => {
             boardLoadError = String(error);
             lastLoadedWorkspacePath = null;
         });

--- a/src/routes/workspace/settings/+page.svelte
+++ b/src/routes/workspace/settings/+page.svelte
@@ -40,18 +40,36 @@
         Search,
         ArrowLeft,
         Renew,
+        MagicWand,
+        ColorPalette,
+        TrashCan,
+        Add,
+        Checkmark,
+        Close,
     } from "carbon-icons-svelte";
+    import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
 
     type SettingsCategory =
         | "general"
         | "appearance"
+        | "customization"
         | "data"
         | "sync"
         | "advanced";
     let activeCategory = $state<SettingsCategory>("general");
+
+    const categories = [
+        { id: "general", label: "General", icon: Settings },
+        { id: "appearance", label: "Appearance", icon: View },
+        { id: "customization", label: "Customization", icon: MagicWand },
+        { id: "data", label: "Data Management", icon: DataBase },
+        { id: "sync", label: "Synchronization", icon: Cloud },
+        { id: "advanced", label: "Advanced", icon: Code },
+    ] as const;
     let searchQuery = $state("");
 
     const workspace = useWorkspace();
+    const { ticketTypesApi } = getWorkspaceShellContext();
     const syncConfig = useSyncConfig();
     const appZoom = useAppZoom();
 
@@ -62,6 +80,40 @@
 
     let exportFormat = $state<ExportFormat>("json");
     let exportMode = $state<ExportMode>("single-file");
+
+    // ── Customization State ───────────────────────────────────────────────
+    let newTypeName = $state("");
+    let newTypeColor = $state("#525252");
+    let editingTypeId = $state<string | null>(null);
+    let editingTypeName = $state("");
+    let editingTypeColor = $state("");
+
+    async function handleAddType() {
+        if (!newTypeName.trim()) return;
+        await ticketTypesApi.create({
+            name: newTypeName.trim(),
+            color: newTypeColor,
+            is_default: ticketTypesApi.types.length === 0,
+        });
+        newTypeName = "";
+    }
+
+    async function handleUpdateType(id: string) {
+        if (!editingTypeName.trim()) return;
+        await ticketTypesApi.update(id, {
+            name: editingTypeName.trim(),
+            color: editingTypeColor,
+        });
+        editingTypeId = null;
+    }
+
+    async function handleDeleteType(id: string) {
+        await ticketTypesApi.remove(id);
+    }
+
+    async function handleSetDefaultType(id: string) {
+        await ticketTypesApi.update(id, { is_default: true });
+    }
 
     // ── Sync state ─────────────────────────────────────────────────────────
     let syncRemoteUrl = $state("");
@@ -321,15 +373,6 @@
 
     // @ts-ignore
     const version = __APP_VERSION__;
-
-    const categories = [
-        { id: "general", label: "General", icon: Settings },
-        { id: "appearance", label: "Appearance", icon: View },
-        { id: "data", label: "Data Management", icon: DataBase },
-        { id: "sync", label: "Synchronization", icon: Cloud },
-        { id: "advanced", label: "Advanced", icon: Code },
-    ] as const;
-
     function matchesSearch(text: string) {
         if (!searchQuery) return true;
         return text.toLowerCase().includes(searchQuery.toLowerCase());
@@ -456,6 +499,144 @@
                             </p>
                             <div class="control-box">
                                 <ZoomControls />
+                            </div>
+                        </section>
+                    {/if}
+                </div>
+            {/if}
+
+            <!-- ── Customization Category ──────────────────────────────── -->
+            {#if activeCategory === "customization"}
+                <div class="category-view">
+                    {#if matchesSearch("Ticket Types Customization Colors Icons")}
+                        <section class="settings-section">
+                            <h2>Ticket Types</h2>
+                            <p class="section-desc">
+                                Manage the types of tickets available in your
+                                workspace. Each type can have its own color and
+                                icon.
+                            </p>
+
+                            <div class="type-management-list">
+                                {#each ticketTypesApi.types as type}
+                                    <div
+                                        class="type-item"
+                                        class:is-default={type.is_default}
+                                    >
+                                        {#if editingTypeId === type.id}
+                                            <div class="type-edit-form">
+                                                <TextInput
+                                                    size="sm"
+                                                    bind:value={editingTypeName}
+                                                />
+                                                <input
+                                                    type="color"
+                                                    bind:value={
+                                                        editingTypeColor
+                                                    }
+                                                    class="color-input-sm"
+                                                />
+                                                <Button
+                                                    size="small"
+                                                    kind="ghost"
+                                                    icon={Checkmark}
+                                                    iconDescription="Save"
+                                                    onclick={() =>
+                                                        handleUpdateType(
+                                                            type.id,
+                                                        )}
+                                                />
+                                                <Button
+                                                    size="small"
+                                                    kind="ghost"
+                                                    icon={Close}
+                                                    iconDescription="Cancel"
+                                                    onclick={() =>
+                                                        (editingTypeId = null)}
+                                                />
+                                            </div>
+                                        {:else}
+                                            <div class="type-display">
+                                                <div
+                                                    class="type-color-dot"
+                                                    style="background-color: {type.color}"
+                                                ></div>
+                                                <span class="type-name"
+                                                    >{type.name}</span
+                                                >
+                                                {#if type.is_default}
+                                                    <Tag size="sm" type="blue"
+                                                        >Default</Tag
+                                                    >
+                                                {/if}
+                                            </div>
+                                            <div class="type-actions">
+                                                {#if !type.is_default}
+                                                    <Button
+                                                        size="small"
+                                                        kind="ghost"
+                                                        onclick={() =>
+                                                            handleSetDefaultType(
+                                                                type.id,
+                                                            )}
+                                                    >
+                                                        Set Default
+                                                    </Button>
+                                                {/if}
+                                                <Button
+                                                    size="small"
+                                                    kind="ghost"
+                                                    icon={Code}
+                                                    iconDescription="Edit"
+                                                    onclick={() => {
+                                                        editingTypeId = type.id;
+                                                        editingTypeName =
+                                                            type.name;
+                                                        editingTypeColor =
+                                                            type.color;
+                                                    }}
+                                                />
+                                                <Button
+                                                    size="small"
+                                                    kind="ghost"
+                                                    icon={TrashCan}
+                                                    iconDescription="Delete"
+                                                    onclick={() =>
+                                                        handleDeleteType(
+                                                            type.id,
+                                                        )}
+                                                />
+                                            </div>
+                                        {/if}
+                                    </div>
+                                {/each}
+                            </div>
+
+                            <div class="add-type-form">
+                                <h3>Add New Type</h3>
+                                <div class="add-type-inputs">
+                                    <TextInput
+                                        labelText="Name"
+                                        placeholder="e.g. Research"
+                                        bind:value={newTypeName}
+                                    />
+                                    <div class="color-picker-group">
+                                        <label for="new-type-color">Color</label
+                                        >
+                                        <input
+                                            id="new-type-color"
+                                            type="color"
+                                            bind:value={newTypeColor}
+                                        />
+                                    </div>
+                                    <Button
+                                        kind="secondary"
+                                        icon={Add}
+                                        onclick={handleAddType}
+                                    >
+                                        Add Type
+                                    </Button>
+                                </div>
                             </div>
                         </section>
                     {/if}
@@ -972,5 +1153,109 @@
         font-size: 0.8125rem;
         color: var(--cds-text-helper);
         margin: 0;
+    }
+
+    /* ── Customization Category ────────────────────────────────────────── */
+    .type-management-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        background: var(--cds-ui-02);
+        padding: 0.5rem;
+        border-radius: 4px;
+        border: 1px solid var(--cds-ui-03);
+    }
+
+    .type-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 1rem;
+        background: var(--cds-ui-01);
+        border-radius: 4px;
+        border: 1px solid transparent;
+        transition: all 0.1s ease;
+    }
+
+    .type-item:hover {
+        border-color: var(--cds-ui-03);
+    }
+
+    .type-item.is-default {
+        border-left: 4px solid var(--cds-interactive-01);
+    }
+
+    .type-display,
+    .type-edit-form {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex: 1;
+    }
+
+    .type-color-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+
+    .type-name {
+        font-size: 0.875rem;
+        color: var(--cds-text-primary);
+        font-weight: 500;
+    }
+
+    .type-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+    }
+
+    .color-input-sm {
+        width: 24px;
+        height: 24px;
+        padding: 0;
+        border: none;
+        background: none;
+        cursor: pointer;
+    }
+
+    .add-type-form {
+        margin-top: 1rem;
+        padding: 1.5rem;
+        background: var(--cds-ui-02);
+        border-radius: 4px;
+        border: 1px solid var(--cds-ui-03);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .add-type-inputs {
+        display: flex;
+        align-items: flex-end;
+        gap: 1.5rem;
+    }
+
+    .color-picker-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .color-picker-group label {
+        font-size: 0.75rem;
+        color: var(--cds-text-secondary);
+    }
+
+    .color-picker-group input {
+        width: 40px;
+        height: 40px;
+        padding: 0;
+        border: 1px solid var(--cds-ui-03);
+        background: var(--cds-ui-01);
+        border-radius: 4px;
+        cursor: pointer;
     }
 </style>


### PR DESCRIPTION
This pull request introduces improved support for custom ticket types throughout the application's UI, ensuring that custom types are displayed with their configured names, colors, and icons in the Gantt board, Kanban board, ticket modals, and table views. Additionally, it updates the version numbers across the project to `1.2.4`.

**Custom Ticket Type Support:**

* Gantt Board:
  - The `GanttState` class and `gantt-board.svelte` now use `ticketTypesApi` to assign the correct color for each ticket row based on its custom type. [[1]](diffhunk://#diff-e944266ed9cae670c86dea7bd6d0df6f5f657bd8fbfee80f4925fddf2dbd9899R20-R26) [[2]](diffhunk://#diff-e5b6db061d19445b3fc0e23b4538f9c10da37c9003d4aa97e312a78826faea5cR45) [[3]](diffhunk://#diff-e5b6db061d19445b3fc0e23b4538f9c10da37c9003d4aa97e312a78826faea5cL60-R63) [[4]](diffhunk://#diff-e5b6db061d19445b3fc0e23b4538f9c10da37c9003d4aa97e312a78826faea5cL172-R175)
  - The Gantt tooltip displays the custom type's name and color for each ticket. [[1]](diffhunk://#diff-e887e46240ccf7b1f9eb68c54db1f60ea0ba2850815d4b141230812b17d57837R10-R20) [[2]](diffhunk://#diff-e887e46240ccf7b1f9eb68c54db1f60ea0ba2850815d4b141230812b17d57837R32-R54)

* Kanban Board:
  - `kanban-ticket-card.svelte` now fetches ticket type information from `ticketTypesApi`, displaying the correct name, color, and icon for custom types. [[1]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacR43-R44) [[2]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacL55-R61) [[3]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacL78-R97) [[4]](diffhunk://#diff-a45ce14ef600efb5b76969ab6604e26289831533e9bb324f582e6e4ecc921eacL203-R224)
  - The ticket add/edit modal uses the custom types from `ticketTypesApi` for the type dropdown, sets the default type based on configuration, and stores the type as a string ID. [[1]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR21-R22) [[2]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffL35-R46) [[3]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffL53-R57) [[4]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR114-R119) [[5]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffL218-R225)

* Table View:
  - `table-group.svelte` now displays ticket type names, colors, and icons using `ticketTypesApi`, replacing the previous static configuration. [[1]](diffhunk://#diff-194131ce9901541a2596aa3ac64e57cfbe0dbd94ff6c6b1b3cf9f6088ab6be6eL2-R23) [[2]](diffhunk://#diff-194131ce9901541a2596aa3ac64e57cfbe0dbd94ff6c6b1b3cf9f6088ab6be6eL68-R170)

**Version Updates:**

* Updated the project version to `1.2.4` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L3-R3) [[3]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4)