### PR TITLE
Add confirmation modals for discarding unsaved changes and prevent Enter key submission

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worklog",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6050,7 +6050,7 @@ dependencies = [
 
 [[package]]
 name = "worklog"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worklog"
-version = "1.2.4"
+version = "1.2.5"
 description = "Local-first desktop project manager for small development teams"
 authors = ["Ezzoubair ZARQI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "worklog",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "plugins": {
     "fs": {
       "requireLiteralLeadingDot": false

--- a/src/lib/components/app/kanban/ticket-add-edit-modal.svelte
+++ b/src/lib/components/app/kanban/ticket-add-edit-modal.svelte
@@ -197,12 +197,18 @@
                 labelText="Title *"
                 placeholder="e.g. Implement login screen"
                 bind:value={form.title}
+                on:keydown={(e) => {
+                    if (e.key === "Enter") e.stopPropagation();
+                }}
             />
             <TextArea
                 labelText="Description"
                 placeholder="Describe the ticket…"
                 rows={6}
                 bind:value={form.description}
+                on:keydown={(e) => {
+                    if (e.key === "Enter") e.stopPropagation();
+                }}
             />
         </div>
 

--- a/src/lib/components/app/layout/workspace/workspace-sidebar.svelte
+++ b/src/lib/components/app/layout/workspace/workspace-sidebar.svelte
@@ -48,6 +48,9 @@
     let draftDescription = $state("");
     let creatingBoard = $state(false);
     let createError = $state<string | null>(null);
+    let showCreateDiscard = $state(false);
+
+    const isCreateDirty = $derived(draftName.trim() !== "" || draftDescription.trim() !== "");
 
     const selectedBoardId = $derived(boardsApi.active?.id ?? undefined);
     const hasBoards = $derived(boardsApi.boards.length > 0);
@@ -87,7 +90,11 @@
     }
 
     function closeCreateBoardModal() {
-        createModalOpen = false;
+        if (isCreateDirty) {
+            showCreateDiscard = true;
+        } else {
+            createModalOpen = false;
+        }
     }
 
     function openSettings() {
@@ -171,6 +178,14 @@
     let editDraftDescription = $state("");
     let editError = $state<string | null>(null);
     let editingBoard = $state(false);
+    let showEditDiscard = $state(false);
+    let initialEditName = $state("");
+    let initialEditDescription = $state("");
+
+    const isEditDirty = $derived(
+        editDraftName.trim() !== initialEditName ||
+        editDraftDescription.trim() !== initialEditDescription
+    );
 
     function promptEditBoard(board: {
         id: string;
@@ -178,10 +193,20 @@
         description?: string;
     }) {
         editBoardId = board.id;
-        editDraftName = board.name;
-        editDraftDescription = board.description || "";
+        initialEditName = board.name;
+        initialEditDescription = board.description || "";
+        editDraftName = initialEditName;
+        editDraftDescription = initialEditDescription;
         editError = null;
         editModalOpen = true;
+    }
+
+    function closeEditBoardModal() {
+        if (isEditDirty) {
+            showEditDiscard = true;
+        } else {
+            editModalOpen = false;
+        }
     }
 
     async function confirmEditBoard() {
@@ -202,6 +227,18 @@
         } finally {
             editingBoard = false;
         }
+    }
+
+    function forceCloseCreate() {
+        draftName = "";
+        draftDescription = "";
+        showCreateDiscard = false;
+        createModalOpen = false;
+    }
+
+    function forceCloseEdit() {
+        showEditDiscard = false;
+        editModalOpen = false;
     }
 
     function promptDeleteBoard(id: string) {
@@ -315,7 +352,13 @@
 <ComposedModal
     bind:open={createModalOpen}
     size="sm"
-    preventCloseOnClickOutside={creatingBoard}
+    preventCloseOnClickOutside
+    on:close={(e) => {
+        if (createModalOpen && isCreateDirty) {
+            e.preventDefault();
+            showCreateDiscard = true;
+        }
+    }}
 >
     <ModalHeader title="Create board" />
 
@@ -336,6 +379,9 @@
             placeholder="Short board description"
             bind:value={draftDescription}
             on:input={handleDescriptionInput}
+            on:keydown={(e) => {
+                if (e.key === "Enter") e.stopPropagation();
+            }}
             rows={4}
             maxlength={180}
         />
@@ -362,7 +408,13 @@
 <ComposedModal
     bind:open={editModalOpen}
     size="sm"
-    preventCloseOnClickOutside={editingBoard}
+    preventCloseOnClickOutside
+    on:close={(e) => {
+        if (editModalOpen && isEditDirty) {
+            e.preventDefault();
+            showEditDiscard = true;
+        }
+    }}
 >
     <ModalHeader title="Edit board" />
 
@@ -375,12 +427,18 @@
             invalid={Boolean(editError && !editDraftName.trim())}
             invalidText="Board name is required."
             data-modal-primary-focus
+            on:keydown={(e) => {
+                if (e.key === "Enter") e.stopPropagation();
+            }}
         />
 
         <TextArea
             labelText="Description"
             placeholder="Short board description"
             bind:value={editDraftDescription}
+            on:keydown={(e) => {
+                if (e.key === "Enter") e.stopPropagation();
+            }}
             rows={4}
             maxlength={180}
         />
@@ -393,7 +451,7 @@
     <ModalFooter>
         <Button
             kind="secondary"
-            on:click={() => (editModalOpen = false)}
+            onclick={closeEditBoardModal}
             disabled={editingBoard}
         >
             Cancel
@@ -422,6 +480,36 @@
         undone.
     </p>
 </Modal>
+
+<ComposedModal
+    danger
+    bind:open={showCreateDiscard}
+    size="sm"
+>
+    <ModalHeader title="Discard unsaved changes?" />
+    <ModalBody>
+        <p>You have unsaved changes in your new board draft. Are you sure you want to discard them?</p>
+    </ModalBody>
+    <ModalFooter>
+        <Button kind="secondary" onclick={() => (showCreateDiscard = false)}>Continue editing</Button>
+        <Button kind="danger" onclick={forceCloseCreate}>Discard changes</Button>
+    </ModalFooter>
+</ComposedModal>
+
+<ComposedModal
+    danger
+    bind:open={showEditDiscard}
+    size="sm"
+>
+    <ModalHeader title="Discard unsaved changes?" />
+    <ModalBody>
+        <p>You have unsaved changes in your board info. Are you sure you want to discard them?</p>
+    </ModalBody>
+    <ModalFooter>
+        <Button kind="secondary" onclick={() => (showEditDiscard = false)}>Continue editing</Button>
+        <Button kind="danger" onclick={forceCloseEdit}>Discard changes</Button>
+    </ModalFooter>
+</ComposedModal>
 
 <style>
     :global(.workspace-sidebar.bx--side-nav) {


### PR DESCRIPTION
This pull request introduces improved user experience and safeguards for board creation and editing modals in the workspace sidebar, along with minor version bumps across the project. The main focus is to prevent accidental loss of unsaved changes by prompting users before discarding edits, and to enhance keyboard handling in form fields.

**User experience improvements for board modals:**

* Added dirty state tracking for both create and edit board modals, prompting users with a discard confirmation modal if they attempt to close with unsaved changes. This prevents accidental data loss when closing the modals via UI or clicking outside. [[1]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R51-R53) [[2]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R93-R98) [[3]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R181-R211) [[4]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R232-R243) [[5]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0L318-R361) [[6]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0L365-R417) [[7]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R484-R513)
* Implemented discard confirmation modals for both create and edit flows, allowing users to either continue editing or discard their unsaved changes.

**Form input handling:**

* Prevented propagation of the Enter key in input fields and textareas within board modals and ticket add/edit modal, reducing the chance of accidental form submissions or modal closures while typing. [[1]](diffhunk://#diff-90300ce9858b04808c658a539589ce77ae8681435add2b70e4852a0040a7fdffR200-R211) [[2]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R382-R384) [[3]](diffhunk://#diff-5b9d607165b35f9bda60495b906fff09c52ee174d570ef9f01181a5941d483f0R430-R441)

**Version updates:**

* Bumped project version to `1.2.5` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` to reflect these changes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L3-R3) [[3]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4)
* Updated the `aur` subproject commit reference.

These changes collectively make the board management experience safer and more user-friendly, and ensure keyboard interactions are less error-prone.