### PR TITLE
Implement centralized loading state and error handling for tickets

### DIFF
--- a/packages/worklog/package.json
+++ b/packages/worklog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worklog",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/packages/worklog/src-tauri/Cargo.lock
+++ b/packages/worklog/src-tauri/Cargo.lock
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "worklog"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/worklog/src-tauri/Cargo.lock
+++ b/packages/worklog/src-tauri/Cargo.lock
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "worklog"
-version = "1.2.17"
+version = "1.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/worklog/src-tauri/Cargo.toml
+++ b/packages/worklog/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worklog"
-version = "1.3.0"
+version = "1.3.1"
 description = "Local-first desktop project manager for small development teams"
 authors = ["Ezzoubair ZARQI"]
 edition = "2021"

--- a/packages/worklog/src-tauri/tauri.conf.json
+++ b/packages/worklog/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "worklog",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "plugins": {
     "fs": {
       "requireLiteralLeadingDot": false

--- a/packages/worklog/src/lib/components/app/kanban/kanban-board.svelte
+++ b/packages/worklog/src/lib/components/app/kanban/kanban-board.svelte
@@ -51,23 +51,7 @@
     let loadError = $state<string | null>(null);
     let actionError = $state<string | null>(null);
 
-    $effect(() => {
-        const workspacePath = getWorkspacePath();
-        const boardId = getBoardId();
-
-        if (!workspacePath || !boardId) {
-            return;
-        }
-
-        void (async () => {
-            try {
-                loadError = null;
-                await ticketsHook.load();
-            } catch (error) {
-                loadError = String(error);
-            }
-        })();
-    });
+    // Loading is now handled by the parent component (+page.svelte)
 
     // ── Column definitions from config ─────────────────────────────────────────
     const columnsDef = TICKET_STATUS_ORDER.map((status) => ({

--- a/packages/worklog/src/lib/hooks/tickets.svelte.ts
+++ b/packages/worklog/src/lib/hooks/tickets.svelte.ts
@@ -25,9 +25,12 @@ export function useTickets(
     async function load() {
         const workspacePath = getWorkspacePath();
         const boardId = getBoardId();
+
+        // Clear existing tickets immediately to avoid flashing old data
+        _tickets = [];
+        _counts = {};
+
         if (!workspacePath || !boardId) {
-            _tickets = [];
-            _counts = {};
             return;
         }
 

--- a/packages/worklog/src/routes/workspace/[board_id]/+page.svelte
+++ b/packages/worklog/src/routes/workspace/[board_id]/+page.svelte
@@ -3,18 +3,25 @@
     import KanbanBoard from "$lib/components/app/kanban/kanban-board.svelte";
     import TableView from "$lib/components/app/table/table-board.svelte";
     import GanttView from "$lib/components/app/gantt/gantt-board.svelte";
-    import { Tabs, Tab, TabContent } from "carbon-components-svelte";
+    import { Tabs, Tab, TabContent, Loading, InlineNotification } from "carbon-components-svelte";
     import { Dashboard, Table, ChartBarFloating } from "carbon-icons-svelte";
     import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
+    import { useTickets } from "$lib/hooks/tickets.svelte";
 
     import type { PageProps } from "./$types";
 
     let { data }: PageProps = $props();
 
-    const { boardsApi } = getWorkspaceShellContext();
+    const shell = getWorkspaceShellContext();
+    const { boardsApi } = shell;
 
     const board = $derived(
         boardsApi.boards.find((item) => item.id === data.boardId) ?? null,
+    );
+
+    const ticketsApi = useTickets(
+        () => shell.workspace.path,
+        () => board?.id ?? null,
     );
 
     function goToWorkspaceRoot() {
@@ -37,6 +44,21 @@
         }
 
         boardsApi.setActive(board);
+    });
+
+    let loadError = $state<string | null>(null);
+
+    // Load tickets when board changes
+    $effect(() => {
+        if (!board) return;
+        void (async () => {
+            try {
+                loadError = null;
+                await ticketsApi.load();
+            } catch (e) {
+                loadError = String(e);
+            }
+        })();
     });
 
     // Save/Restore tab index (Board-specific)
@@ -82,6 +104,22 @@
         </header>
 
         <section class="workspace-board-content" aria-label="Board content">
+            {#if loadError}
+                <div class="workspace-board-error">
+                    <InlineNotification
+                        kind="error"
+                        title="Failed to load board data"
+                        subtitle={loadError}
+                        hideCloseButton
+                    />
+                </div>
+            {/if}
+
+            {#if ticketsApi.loading}
+                <div class="workspace-board-loading">
+                    <Loading withOverlay={false} description="Loading board data..." />
+                </div>
+            {/if}
             <Tabs autoWidth bind:selected={selectedTab}>
                 <Tab label="Board" icon={Dashboard} />
                 <Tab label="Table" icon={Table} />
@@ -150,6 +188,29 @@
         min-height: 0;
         display: flex;
         flex-direction: column;
+        position: relative;
+    }
+
+    .workspace-board-loading {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: grid;
+        place-items: center;
+        background: var(--cds-ui-background);
+        z-index: 1000;
+        animation: workspace-board-fade-in 0.2s ease-out;
+    }
+
+    @keyframes workspace-board-fade-in {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
+        }
     }
 
     /* Make Tabs container take full height */
@@ -162,5 +223,9 @@
         min-height: 0;
         padding: 0 !important;
         overflow: hidden;
+    }
+
+    .workspace-board-error {
+        padding: var(--cds-spacing-05, 1rem);
     }
 </style>


### PR DESCRIPTION
This pull request refactors how ticket data is loaded for the Kanban board, shifting responsibility from the Kanban board component to the parent page. It introduces improved loading and error states for a better user experience, and updates version numbers across project files.

**Refactor: Ticket Data Loading**
- Moved the responsibility for loading tickets from the `kanban-board.svelte` component to the parent `+page.svelte` file, ensuring data loading is centralized and easier to manage. (`kanban-board.svelte`, `+page.svelte`) ([packages/worklog/src/lib/components/app/kanban/kanban-board.svelteL54-R54](diffhunk://#diff-dd7db7aec288907afc7f672cd26f69993d8f0387878500b1fae0d47a19735c0aL54-R54), [packages/worklog/src/routes/workspace/[board_id]/+page.svelteL6-R26](diffhunk://#diff-6de93f768ceb8a140e57b4584079afaa100f4e43bdba0eb5d18caa958578bd43L6-R26), [packages/worklog/src/routes/workspace/[board_id]/+page.svelteR49-R63](diffhunk://#diff-6de93f768ceb8a140e57b4584079afaa100f4e43bdba0eb5d18caa958578bd43R49-R63))

**User Experience Improvements**
- Added visual loading and error states to the board view, displaying a loading spinner while tickets are fetched and an inline error notification if loading fails. (`+page.svelte`) ([packages/worklog/src/routes/workspace/[board_id]/+page.svelteR107-R122](diffhunk://#diff-6de93f768ceb8a140e57b4584079afaa100f4e43bdba0eb5d18caa958578bd43R107-R122), [packages/worklog/src/routes/workspace/[board_id]/+page.svelteR191-R213](diffhunk://#diff-6de93f768ceb8a140e57b4584079afaa100f4e43bdba0eb5d18caa958578bd43R191-R213), [packages/worklog/src/routes/workspace/[board_id]/+page.svelteR227-R230](diffhunk://#diff-6de93f768ceb8a140e57b4584079afaa100f4e43bdba0eb5d18caa958578bd43R227-R230))
- Updated the `useTickets` hook to immediately clear old ticket data when loading new data, preventing stale data from flashing on the UI. (`tickets.svelte.ts`)

**Version Bumps**
- Updated the version number to `1.3.1` in `package.json`, `Cargo.toml`, and `tauri.conf.json` to reflect these changes. (`package.json`, `Cargo.toml`, `tauri.conf.json`) [[1]](diffhunk://#diff-e56ae99fbfdb478e16a649e72d33d04cab754a7ed98e5a74488a095822d6d778L3-R3) [[2]](diffhunk://#diff-3b004aefc2ba2951d328e4be6be369f13deae876d1d2426ab5da845e1259829eL3-R3) [[3]](diffhunk://#diff-b04ac8e8ea6a79d625729af9cefcf36a5cb5966f1965fa0ae90693d83dbb1458L4-R4)