### PR TITLE
Prevent false discard popup for unsaved changes in create board modal

### DIFF
--- a/packages/worklog/src/lib/components/app/layout/workspace/workspace-sidebar.svelte
+++ b/packages/worklog/src/lib/components/app/layout/workspace/workspace-sidebar.svelte
@@ -93,12 +93,14 @@
         createError = null;
     }
 
-    function closeCreateBoardModal() {
-        if (isCreateDirty) {
+    function closeCreateBoardModal(options?: { ignoreDirty?: boolean }) {
+        if (!options?.ignoreDirty && isCreateDirty) {
             showCreateDiscard = true;
-        } else {
-            createModalOpen = false;
+            return;
         }
+
+        createModalOpen = false;
+        showCreateDiscard = false;
     }
 
     function openSettings() {
@@ -135,7 +137,7 @@
                 description: draftDescription.trim(),
             });
 
-            closeCreateBoardModal();
+            closeCreateBoardModal({ ignoreDirty: true });
             onOpenBoard(createdBoard.id);
         } catch (error) {
             createError = String(error);
@@ -437,7 +439,7 @@
     <ModalFooter>
         <Button
             kind="secondary"
-            onclick={closeCreateBoardModal}
+            onclick={() => closeCreateBoardModal()}
             disabled={creatingBoard}
         >
             Cancel


### PR DESCRIPTION
This pull request updates the logic for closing the "Create Board" modal in the `workspace-sidebar.svelte` component to provide better handling of unsaved changes and modal state. The main improvements are centered around making the modal's close behavior more flexible and explicit, especially when discarding or saving a new board.

**Improvements to modal close logic:**

* Updated `closeCreateBoardModal` to accept an optional `ignoreDirty` flag, allowing the modal to be closed without prompting for unsaved changes when appropriate.
* Modified the board creation flow to call `closeCreateBoardModal` with `{ ignoreDirty: true }` after successfully creating a board, ensuring the modal closes cleanly without unnecessary prompts.
* Updated the "Cancel" button's click handler to use the new close function signature.

**Dependency update:**

* Updated the `aur` submodule to a new commit.