### PR TITLE
feat: unify ticket management by merging useTickets and useAllTickets…

### DIFF
--- a/docs/improvements.md
+++ b/docs/improvements.md
@@ -1,0 +1,280 @@
+# Worklog — Improvement Analysis
+
+> Generated: May 31, 2026
+> Based on full codebase review of `packages/worklog`
+
+---
+
+## Overall Assessment
+
+The project has a **solid foundation**: clean SvelteKit + Tauri v2 architecture, runes-based state management, good separation of concerns (hooks / repositories), and a clear local-first philosophy. Below are the areas that need attention, roughly ordered by impact.
+
+---
+
+## 🔴 Critical / High Impact
+
+### 1. Git Access Token Stored in Plaintext
+
+| Area | Files |
+|---|---|
+| Security | `src/lib/sync/types.ts`, `src/lib/sync/git-client.ts` |
+
+The GitHub Personal Access Token is stored **unencrypted** in the SQLite `sync_config` table and embedded directly into HTTPS URLs (`https://${token}@github.com/...`). Anyone with filesystem access to the `.worklog/` directory can read it. There is also risk of token leak through `git remote -v` output.
+
+**Recommendation:** Use the OS keychain (via `tauri-plugin-store` with encryption, or `secret-service` APIs on Linux), or at minimum store an encrypted version. Never embed tokens in remote URLs that could leak through git metadata.
+
+---
+
+### 2. Rust Backend Is Largely Scaffolding
+
+| Area | File |
+|---|---|
+| Performance | `src-tauri/src/lib.rs` |
+
+The only Tauri command is the boilerplate `greet` — never called by any front-end code. All business logic lives in JS/TS. This means every database query, file read, and git operation marshals through the Tauri plugin IPC layer. Performance-sensitive operations (batch inserts, complex joins, file scanning) could be **10–100× faster** as native Rust commands.
+
+**Recommendation:** Move at least the DB repository layer to Rust commands. Start with performance-critical paths: ticket batch operations, search, and sync snapshot generation.
+
+---
+
+### 3. Duplicate & Stale Ticket State ✅ Fixed
+
+| Area | Files |
+|---|---|
+| Architecture | `src/lib/hooks/tickets.svelte.ts`, `src/lib/hooks/all-tickets.svelte.ts` |
+
+Two independent hooks maintained their own `_tickets` arrays, causing stale data across different views.
+
+**Fix applied:** Merged `useTickets` and `useAllTickets` into a single unified `useTickets` hook in `src/lib/hooks/tickets.svelte.ts`. Both modes (board-scoped paginated, and all-tickets) now share the same module-level reactive `_tickets` state. Mutations from any view (`create/update/remove/addComment`) are immediately reflected in all consumers. `useAllTickets` is preserved as a deprecated re-export for backward compatibility.
+
+---
+
+### 4. `window.location.reload()` After Data Mutations
+
+| Area | File |
+|---|---|
+| UX | `src/routes/+layout.svelte` (import function) |
+
+After a successful data import, the app does a full hard reload (`window.location.reload()`). This destroys all in-memory state, causes a visual flash, and is poor UX.
+
+**Recommendation:** After import, invalidate the relevant hooks (`boardsApi.load()`, `ticketsHook.load()`) instead of reloading the window.
+
+---
+
+## 🟡 Medium Impact
+
+### 5. Three Different Drag-and-Drop Libraries
+
+| Area | File |
+|---|---|
+| Bundle size | `package.json` (dependencies) |
+
+Three DnD libraries for one app — `@dnd-kit-svelte/svelte`, `svelte-dnd-action`, and `@thisux/sveltednd` — is unnecessary weight and complexity. The Kanban board uses `svelte-dnd-action` but the other two also exist as dependencies. This adds ~50–100+ KB to the bundle and increases maintenance burden.
+
+**Recommendation:** Pick one DnD library and remove the others.
+
+---
+
+### 6. Heavy Carbon Components Bundle
+
+| Area | File |
+|---|---|
+| Bundle size | `src/routes/+layout.svelte` |
+
+Importing the full Carbon CSS (`import "carbon-components-svelte/css/all.css"`) adds significant bloat — hundreds of KB of CSS. The `carbon-preprocess-svelte` plugin with `optimizeImports()` is configured in `svelte.config.js`, but the full CSS import bypasses tree-shaking entirely.
+
+**Recommendation:** Import only the individual Carbon component CSS files that are actually used, or consider moving away from Carbon given the project's custom visual direction (glass, dark, compact surfaces).
+
+---
+
+### 7. Unused and Orphaned Dependencies
+
+| Package | Likely Issue |
+|---|---|
+| `clsx` + `tailwind-merge` | `cn()` utility exists in `utils.ts` but Tailwind is **not configured** anywhere |
+| `layerchart`, `d3-scale`, `d3-shape` | Heavy charting libraries — unclear if still in use |
+| `bits-ui`, `vaul-svelte` | Shadcn-style primitives in devDependencies, unclear usage |
+| `carbon-preprocess-svelte` | Optimizer configured but defeated by full CSS import |
+
+**Recommendation:** Audit all dependencies. Run `bun run check` after removing each unused package.
+
+---
+
+### 8. `getDb()` Runs CREATE + Migrations on Every Call
+
+| Area | File |
+|---|---|
+| Performance | `src/lib/db/connection.ts` |
+
+Every call to `getDb()` executes `CREATE TABLE IF NOT EXISTS` statements and triggers migration logic — even for read-only operations. This is wasted I/O on every ticket/board fetch.
+
+**Recommendation:** Separate connection acquisition from schema initialization. Run schema + migrations only once after the database is first opened, not on every `getDb()` call.
+
+---
+
+### 9. Race Condition Risk in Workspace Init
+
+| Area | File |
+|---|---|
+| Reliability | `src/lib/hooks/workspace.svelte.ts` |
+
+```typescript
+await open_workspace(saved);
+if (_path !== saved) {  // _path may have been partially updated before a throw
+```
+
+If `open_workspace()` partially updates `_path` then throws, the comparison and cleanup logic can misbehave and leave state inconsistent.
+
+**Recommendation:** Use a clear transactional pattern — set `_path` only after `open_workspace()` fully succeeds, and catch errors before mutating state.
+
+---
+
+### 10. Notifications Dropped When Queue Not Mounted
+
+| Area | File |
+|---|---|
+| UX | `src/lib/hooks/notifications.svelte.ts` |
+
+`notifications.add()` silently drops notifications (with only a `console.warn`) if the Carbon `NotificationQueue` component hasn't mounted yet. This can happen during initial load or route transitions.
+
+**Recommendation:** Buffer notifications until the queue ref is available, or use an independent notification system not tied to a component `bind:this`.
+
+---
+
+## 🟢 Lower Impact / Polish
+
+### 11. `use*` Naming Convention for Singletons
+
+| Area | Files |
+|---|---|
+| Clarity | All `src/lib/hooks/*.svelte.ts` |
+
+Functions like `useWorkspace()`, `useBoards()`, `useCommandPalette()` are module-level singletons, not per-component instances. The `use*` prefix implies they should be called at the component level. This is confusing — especially since `useTickets()` creates **new independent state** while `useWorkspace()` returns the same singleton every time.
+
+**Recommendation:** Rename module-level singletons to `getWorkspace()`, `workspaceState`, or similar to make the distinction clear.
+
+---
+
+### 12. Leftover Debug Comments
+
+| Area | File |
+|---|---|
+| Cleanliness | `src/routes/workspace/+layout.svelte` |
+
+```svelte
+<!-- <h1>Hello World</h1>
+<h1>Hello World</h1>
+<h1>Hello World</h1>
+<h1>{JSON.stringify(}</h1> -->
+```
+
+**Recommendation:** Remove commented-out debug markup.
+
+---
+
+### 13. i18n Detection Runs on Every Layout Render
+
+| Area | File |
+|---|---|
+| Performance | `src/routes/+layout.svelte` (top-level script block) |
+
+The language detection and `localStorage` read run on every component instantiation, not just once at app boot.
+
+**Recommendation:** Guard with a module-level `let initialized = false` flag, or move to an `$effect` / `$effect.root`.
+
+---
+
+### 14. Hard Reliance on `customEvent` for Cross-Component Communication
+
+| Area | File |
+|---|---|
+| Maintainability | `src/routes/+layout.svelte` |
+
+Actions like "create board", "create ticket", "toggle theme" are dispatched as `window` custom events. This is fragile — no TypeScript checking, no way to trace listeners, and no compile-time guarantees.
+
+**Recommendation:** Use Svelte context API or shared reactive state (the hooks already exist) instead of custom events.
+
+---
+
+### 15. Scrollbar Suppression Is a Fragile Hack
+
+| Area | File |
+|---|---|
+| CSS | `src/routes/layout.css` |
+
+```css
+html.preview-open *::-webkit-scrollbar {
+  display: none !important;
+}
+```
+
+This disables **all** scrollbars globally when the preview sheet is open, relying on WebKitGTK compositing behavior. It is brittle across browser versions and platforms.
+
+**Recommendation:** Target scroll suppression at the specific scrollable containers that overlap with the sheet, rather than the entire document.
+
+---
+
+### 16. No Test Infrastructure
+
+| Area | Scope |
+|---|---|
+| Quality | Entire project |
+
+The project has zero tests — no unit tests, no integration tests, no E2E tests. For a data-management application that handles migrations, sync, and import/export, this is a significant risk.
+
+**Recommendation:** Start with Vitest for unit tests on repositories and hooks, then add Playwright E2E tests for critical flows (workspace open, board CRUD, ticket CRUD, drag-and-drop).
+
+---
+
+### 17. `$effect.root()` at Module Level in App Zoom
+
+| Area | File |
+|---|---|
+| Correctness | `src/lib/hooks/app-zoom.svelte.ts` |
+
+Using `$effect.root()` at module scope for a persistent effect is unconventional. The `init()` method is now a no-op. Module-level effects can cause unexpected behavior if the module is re-imported or hot-reloaded during development.
+
+**Recommendation:** Restructure to use a plain `$effect` inside the layout component, or use the standard `$state` + manual persistence pattern without module-level effects.
+
+---
+
+## Quick Wins Summary
+
+| Priority | Task | Estimated Effort |
+|---|---|---|
+| 🔴 | Remove dead `greet` Rust command | 5 minutes |
+| 🟡 | Clean up debug comments in workspace layout | 1 minute |
+| 🟡 | Audit and remove unused dependencies | 30 minutes |
+| 🟡 | Replace `window.location.reload()` with hook invalidation | 1–2 hours |
+| 🟢 | Fix i18n initialization to run once | 15 minutes |
+| 🟢 | Consolidate three DnD libraries into one | 2–3 hours |
+| 🔴 | Centralize ticket state management (`useTickets` vs `useAllTickets`) | ✅ Done |
+| 🔴 | Encrypt stored access token or use OS keychain | 4–6 hours |
+| 🔴 | Move critical DB operations to Rust commands | Medium-term |
+| 🟡 | Separate DB connection from schema initialization | 2–3 hours |
+| 🟡 | Add test infrastructure (Vitest + Playwright) | 1–2 weeks |
+| 🟢 | Replace custom events with context/state | 2–3 hours |
+
+---
+
+## Architecture Diagram (Current vs. Target)
+
+```mermaid
+flowchart TD
+    subgraph Current
+        UI[UI Components] --> Hooks[Hooks .svelte.ts]
+        Hooks --> getDb[getDb() - JS/TS]
+        getDb --> SQLite[SQLite via tauri-plugin-sql]
+        Hooks --> GitClient[GitClient - JS shell]
+        GitClient --> GitCLI[system git CLI]
+    end
+
+    subgraph Target
+        UI2[UI Components] --> Hooks2[Hooks .svelte.ts]
+        Hooks2 --> RustCmds[Rust Tauri Commands]
+        RustCmds --> SQLite2[SQLite direct]
+        RustCmds --> Git2[Git via git2 crate]
+    end
+```
+
+Moving DB and git operations to native Rust commands eliminates the IPC marshalling overhead, removes the system git CLI dependency, and keeps the access token in process memory instead of plaintext on disk.

--- a/packages/worklog/src/lib/components/app/calendar/global-calendar-board.svelte
+++ b/packages/worklog/src/lib/components/app/calendar/global-calendar-board.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
     import { InlineNotification } from "carbon-components-svelte";
-    import { useAllTickets } from "$lib/hooks/all-tickets.svelte";
+    import { useTickets } from "$lib/hooks/tickets.svelte";
     import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
-    import type { Ticket, TicketStatus, Comment } from "$lib/components/app/types";
+    import type {
+        Ticket,
+        TicketStatus,
+        Comment,
+    } from "$lib/components/app/types";
     import { CalendarState, setCalendarState } from "./calendar-state.svelte";
     import CalendarHeader from "./calendar-header.svelte";
     import CalendarGrid from "./calendar-grid.svelte";
@@ -15,13 +19,15 @@
 
     const shell = getWorkspaceShellContext();
     const getWorkspacePath = () => shell.workspace.path;
-    const ticketsHook = useAllTickets(getWorkspacePath);
+    const ticketsHook = useTickets(getWorkspacePath);
 
     // Create a proxy hook for the calendar state to prefix board names to titles
     const proxyTicketsHook = {
         get tickets(): Ticket[] {
             return ticketsHook.tickets.map((t) => {
-                const board = shell.boardsApi.boards.find((b) => b.id === t.board_id);
+                const board = shell.boardsApi.boards.find(
+                    (b) => b.id === t.board_id,
+                );
                 const boardName = board?.name ?? "Unknown";
                 return {
                     ...t,
@@ -30,7 +36,9 @@
                 } as Ticket & { _originalTitle: string };
             });
         },
-        get loading() { return ticketsHook.loading; },
+        get loading() {
+            return ticketsHook.loading;
+        },
         load: () => ticketsHook.load(),
     };
 
@@ -51,13 +59,15 @@
 
     const previewTicket = $derived(
         previewTicketId
-            ? (ticketsHook.tickets.find((t) => t.id === previewTicketId) ?? null)
+            ? (ticketsHook.tickets.find((t) => t.id === previewTicketId) ??
+                  null)
             : null,
     );
 
     // Editing from global calendar will retain the original title
     function openEditModal(ticket: Ticket) {
-        editTicket = ticketsHook.tickets.find(t => t.id === ticket.id) ?? ticket;
+        editTicket =
+            ticketsHook.tickets.find((t) => t.id === ticket.id) ?? ticket;
         editModalOpen = true;
     }
 
@@ -99,7 +109,9 @@
             const db = await getDb(workspacePath);
             const settings = await SettingsRepo.getSettings(db);
             author = settings.author_name?.trim() || "Anonymous";
-        } catch { /* use fallback */ }
+        } catch {
+            /* use fallback */
+        }
         const comment: Comment = {
             author,
             body,
@@ -110,7 +122,7 @@
 
     const hasNoDateTickets = $derived(
         calendar.filteredTickets.length > 0 &&
-        calendar.filteredTickets.every((t) => !t.due_date && !t.start_date)
+            calendar.filteredTickets.every((t) => !t.due_date && !t.start_date),
     );
 </script>
 
@@ -130,7 +142,9 @@
 
     <CalendarGrid
         onTicketClick={openPreviewSheet}
-        onDateClick={() => { /* Creating tickets from global calendar is disabled */ }}
+        onDateClick={() => {
+            /* Creating tickets from global calendar is disabled */
+        }}
     />
 </div>
 
@@ -151,11 +165,17 @@
     <TicketPreviewSheet
         bind:open={previewOpen}
         ticket={previewTicket}
-        onEdit={(t) => { previewOpen = false; openEditModal(t); }}
+        onEdit={(t) => {
+            previewOpen = false;
+            openEditModal(t);
+        }}
         onDelete={(id) => {
             previewOpen = false;
             const t = ticketsHook.tickets.find((t) => t.id === id);
-            if (t) { deleteTarget = t; deleteModalOpen = true; }
+            if (t) {
+                deleteTarget = t;
+                deleteModalOpen = true;
+            }
         }}
         onStatusChange={handleStatusChange}
         onAddComment={handleAddComment}

--- a/packages/worklog/src/lib/components/app/overview/workspace-overview.svelte
+++ b/packages/worklog/src/lib/components/app/overview/workspace-overview.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
     import { getWorkspaceShellContext } from "$lib/hooks/workspace-shell-context";
-    import { useAllTickets } from "$lib/hooks/all-tickets.svelte";
+    import { useTickets } from "$lib/hooks/tickets.svelte";
     import { ProgressBar, Tile } from "carbon-components-svelte";
     import { TICKET_STATUS_CONFIG } from "$lib/components/app/types";
     import * as m from "$lib/paraglide/messages.js";
 
     const shell = getWorkspaceShellContext();
     const getWorkspacePath = () => shell.workspace.path;
-    const ticketsHook = useAllTickets(getWorkspacePath);
+    const ticketsHook = useTickets(getWorkspacePath);
 
     $effect(() => {
         void ticketsHook.load();
@@ -67,15 +67,21 @@
                 <div class="metrics-grid">
                     <div class="metric">
                         <span class="metric-val">{totalBoards}</span>
-                        <span class="metric-label">{m.overview_active_boards()}</span>
+                        <span class="metric-label"
+                            >{m.overview_active_boards()}</span
+                        >
                     </div>
                     <div class="metric">
                         <span class="metric-val">{totalTickets}</span>
-                        <span class="metric-label">{m.overview_total_tickets()}</span>
+                        <span class="metric-label"
+                            >{m.overview_total_tickets()}</span
+                        >
                     </div>
                     <div class="metric">
                         <span class="metric-val">{completionRate}%</span>
-                        <span class="metric-label">{m.overview_completion()}</span>
+                        <span class="metric-label"
+                            >{m.overview_completion()}</span
+                        >
                     </div>
                 </div>
                 <div class="progress-wrap">

--- a/packages/worklog/src/lib/hooks/all-tickets.svelte.ts
+++ b/packages/worklog/src/lib/hooks/all-tickets.svelte.ts
@@ -1,63 +1,7 @@
-import type { Ticket, UpdateTicketInput, Comment } from '$lib/components/app/types';
-import { getDb, TicketRepo } from '$lib/db';
-
-let _tickets = $state<Ticket[]>([]);
-let _loading = $state(false);
-
-export function useAllTickets(getWorkspacePath: () => string | null) {
-    function requireWorkspacePath(): string {
-        const path = getWorkspacePath();
-        if (!path) throw new Error('No workspace selected');
-        return path;
-    }
-
-    async function load() {
-        const workspacePath = getWorkspacePath();
-        
-        // Clear existing tickets immediately to avoid flashing old data
-        _tickets = [];
-
-        if (!workspacePath) {
-            return;
-        }
-
-        _loading = true;
-        try {
-            const db = await getDb(workspacePath);
-            _tickets = await TicketRepo.listAllTickets(db);
-        } finally {
-            _loading = false;
-        }
-    }
-
-    async function update(id: string, input: UpdateTicketInput) {
-        const workspacePath = requireWorkspacePath();
-        const db = await getDb(workspacePath);
-        const ticket = await TicketRepo.updateTicket(db, id, input);
-        
-        _tickets = _tickets.map(t => t.id === id ? ticket : t).sort((a, b) => a.position - b.position);
-        
-        return ticket;
-    }
-
-    async function addComment(id: string, comment: Comment) {
-        const ticket = _tickets.find(t => t.id === id);
-        if (!ticket) throw new Error(`Ticket ${id} not found`);
-
-        const updatedComments: Comment[] = [...ticket.comments, comment];
-        return update(id, { comments: updatedComments });
-    }
-
-    async function remove(id: string) {
-        const workspacePath = requireWorkspacePath();
-        const db = await getDb(workspacePath);
-        await TicketRepo.deleteTicket(db, id);
-        _tickets = _tickets.filter(t => t.id !== id);
-    }
-
-    return {
-        get tickets() { return _tickets },
-        get loading() { return _loading },
-        load, update, addComment, remove
-    };
-}
+/**
+ * Re-export from the unified tickets hook.
+ *
+ * @deprecated Import `useTickets` from `$lib/hooks/tickets.svelte` instead.
+ *   `useAllTickets(path)` is equivalent to `useTickets(path)` (no board scope).
+ */
+export { useAllTickets } from './tickets.svelte';

--- a/packages/worklog/src/lib/hooks/tickets.svelte.ts
+++ b/packages/worklog/src/lib/hooks/tickets.svelte.ts
@@ -2,59 +2,89 @@ import type { Ticket, CreateTicketInput, UpdateTicketInput, Comment } from '$lib
 import { getDb, TicketRepo } from '$lib/db';
 
 
+// ── Module-level shared state ──────────────────────────────────────────────
+// All consumers share the same reactive _tickets array, so mutations in one
+// view (e.g. Kanban reorder) are reflected in every other view (e.g. Overview).
+//
+// Two load modes:
+//   board mode (getBoardId returns a string) — paginated per-status loading
+//   all mode   (getBoardId returns null)     — loads every ticket in the workspace
+//
+// The mode is determined by whether a boardId getter is supplied at call time.
+
+type TicketsMode = 'board' | 'all';
+
 let _tickets = $state<Ticket[]>([]);
 let _counts = $state<Record<string, number>>({});
 let _loading = $state(false);
+let _mode = $state<TicketsMode | null>(null);
 
+/**
+ * Unified ticket hook — replaces both useTickets and useAllTickets.
+ *
+ * Pass a boardId getter to load board-scoped tickets (paginated by status).
+ * Omit it (or return null) to load all tickets across the workspace.
+ *
+ * Example — board scope:
+ *   const tickets = useTickets(() => path, () => boardId);
+ *
+ * Example — all scope:
+ *   const tickets = useTickets(() => path);
+ */
 export function useTickets(
     getWorkspacePath: () => string | null,
-    getBoardId: () => string | null,
+    getBoardId?: () => string | null,
 ) {
+    const hasBoardScope = !!getBoardId;
+
     function requireWorkspacePath(): string {
         const path = getWorkspacePath();
         if (!path) throw new Error('No workspace selected');
         return path;
     }
 
-    function requireBoardId(): string {
-        const boardId = getBoardId();
-        if (!boardId) throw new Error('No active board selected');
-        return boardId;
-    }
-
+    // ── Load ────────────────────────────────────────────────────────────────
     async function load() {
         const workspacePath = getWorkspacePath();
-        const boardId = getBoardId();
+        const boardId = hasBoardScope ? getBoardId!() : null;
 
         // Clear existing tickets immediately to avoid flashing old data
         _tickets = [];
         _counts = {};
 
-        if (!workspacePath || !boardId) {
-            return;
-        }
+        if (!workspacePath) return;
 
+        // In board mode, also require a board ID
+        if (hasBoardScope && !boardId) return;
+
+        _mode = hasBoardScope ? 'board' : 'all';
         _loading = true;
         try {
             const db = await getDb(workspacePath);
-            
-            // Fetch initial batches for all statuses to ensure columns aren't empty
-            const statuses: string[] = ["backlog", "todo", "in_progress", "done"];
-            const [batchResults, countResults] = await Promise.all([
-                Promise.all(statuses.map(s => TicketRepo.listTickets(db, boardId, { status: s, limit: 20 }))),
-                Promise.all(statuses.map(s => TicketRepo.countTicketsByStatus(db, boardId, s)))
-            ]);
 
-            _tickets = batchResults.flat();
-            _counts = Object.fromEntries(statuses.map((s, i) => [s, countResults[i]]));
+            if (hasBoardScope && boardId) {
+                // ── Board-scoped: paginated by status ────────────────────────
+                const statuses: string[] = ["backlog", "todo", "in_progress", "done"];
+                const [batchResults, countResults] = await Promise.all([
+                    Promise.all(statuses.map(s => TicketRepo.listTickets(db, boardId, { status: s, limit: 20 }))),
+                    Promise.all(statuses.map(s => TicketRepo.countTicketsByStatus(db, boardId, s)))
+                ]);
+
+                _tickets = batchResults.flat();
+                _counts = Object.fromEntries(statuses.map((s, i) => [s, countResults[i]]));
+            } else {
+                // ── All tickets: full workspace ──────────────────────────────
+                _tickets = await TicketRepo.listAllTickets(db);
+            }
         } finally {
             _loading = false;
         }
     }
 
+    // ── Load More (board scope only) ────────────────────────────────────────
     async function loadMore(status: string) {
         const workspacePath = getWorkspacePath();
-        const boardId = getBoardId();
+        const boardId = hasBoardScope ? getBoardId!() : null;
         if (!workspacePath || !boardId) return;
 
         const currentCount = _tickets.filter(t => t.status === status).length;
@@ -63,16 +93,17 @@ export function useTickets(
         if (currentCount >= total) return;
 
         const db = await getDb(workspacePath);
-        const batch = await TicketRepo.listTickets(db, boardId, { 
-            status, 
-            limit: 20, 
-            offset: currentCount 
+        const batch = await TicketRepo.listTickets(db, boardId, {
+            status,
+            limit: 20,
+            offset: currentCount
         });
 
         // Append new tickets and sort them by position
         _tickets = [..._tickets, ...batch].sort((a, b) => a.position - b.position);
     }
 
+    // ── Create ──────────────────────────────────────────────────────────────
     async function create(input: CreateTicketInput) {
         const workspacePath = requireWorkspacePath();
         const db = await getDb(workspacePath);
@@ -84,24 +115,25 @@ export function useTickets(
         return ticket;
     }
 
+    // ── Update ──────────────────────────────────────────────────────────────
     async function update(id: string, input: UpdateTicketInput) {
         const workspacePath = requireWorkspacePath();
-        requireBoardId();
         const db = await getDb(workspacePath);
         const oldTicket = _tickets.find(t => t.id === id);
         const ticket = await TicketRepo.updateTicket(db, id, input);
-        
+
         _tickets = _tickets.map(t => t.id === id ? ticket : t).sort((a, b) => a.position - b.position);
-        
+
         // Update counts if status changed
         if (oldTicket && input.status && oldTicket.status !== input.status) {
             _counts[oldTicket.status] = Math.max(0, (_counts[oldTicket.status] ?? 0) - 1);
             _counts[input.status] = (_counts[input.status] ?? 0) + 1;
         }
-        
+
         return ticket;
     }
 
+    // ── Add Comment ─────────────────────────────────────────────────────────
     async function addComment(id: string, comment: Comment) {
         const ticket = _tickets.find(t => t.id === id);
         if (!ticket) throw new Error(`Ticket ${id} not found`);
@@ -110,9 +142,9 @@ export function useTickets(
         return update(id, { comments: updatedComments });
     }
 
+    // ── Remove ──────────────────────────────────────────────────────────────
     async function remove(id: string) {
         const workspacePath = requireWorkspacePath();
-        requireBoardId();
         const ticket = _tickets.find(t => t.id === id);
         const db = await getDb(workspacePath);
         await TicketRepo.deleteTicket(db, id);
@@ -126,6 +158,14 @@ export function useTickets(
         get tickets() { return _tickets },
         get counts() { return _counts },
         get loading() { return _loading },
+        get mode() { return _mode },
         load, loadMore, create, update, addComment, remove
     };
+}
+
+// ── Backward-compatible alias ───────────────────────────────────────────────
+// useAllTickets(getWorkspacePath) === useTickets(getWorkspacePath)
+/** @deprecated Use `useTickets(path)` instead. Will be removed in a future release. */
+export function useAllTickets(getWorkspacePath: () => string | null) {
+    return useTickets(getWorkspacePath);
 }


### PR DESCRIPTION
###  Duplicate & Stale Ticket State (Fixed)

| Area | Files |
|---|---|
| Architecture | `src/lib/hooks/tickets.svelte.ts`, `src/lib/hooks/all-tickets.svelte.ts` |

Two independent hooks maintained their own `_tickets` arrays, causing stale data across different views.

**Fix applied:** Merged `useTickets` and `useAllTickets` into a single unified `useTickets` hook in `src/lib/hooks/tickets.svelte.ts`. Both modes (board-scoped paginated, and all-tickets) now share the same module-level reactive `_tickets` state. Mutations from any view (`create/update/remove/addComment`) are immediately reflected in all consumers. `useAllTickets` is preserved as a deprecated re-export for backward compatibility.
