### PR TITLE
Fix Windows forbidden path error by updating filesystem access

### DIFF
--- a/docs/fix-windows-forbidden-path.md
+++ b/docs/fix-windows-forbidden-path.md
@@ -8,31 +8,42 @@ On Windows 11, reopening Worklog after selecting a workspace folder results in a
 
 ## Root Cause
 
-Tauri v2's `tauri-plugin-fs` enforces strict filesystem access scopes defined in `src-tauri/capabilities/default.json`. The scopes were limited to `$DOCUMENT/**/*` and `$HOME/**/*` — but the user-chosen workspace path often falls outside these:
+Tauri v2's `tauri-plugin-fs` enforces strict filesystem access scopes defined in `src-tauri/capabilities/default.json`. The scopes were originally limited to drive-specific variables (`$DOCUMENT`, `$HOME`, `$APPDATA`, `$RESOURCE`, `$DESKTOP`) — all of which resolve to paths on the `C:` drive on Windows.
 
-| Scope variable | Windows 11 resolution | In original config? |
-|---|---|---|
-| `$DOCUMENT` | `C:\Users\<user>\Documents` | ✅ |
-| `$HOME` | `C:\Users\<user>` | ✅ |
-| `$RESOURCE` | The app's install directory (same dir as `worklog.exe`) | ❌ |
-| `$APPDATA` | `C:\Users\<user>\AppData\Roaming` | ❌ |
-| `$DESKTOP` | `C:\Users\<user>\Desktop` | ❌ |
+When a user selected a workspace on a **different drive** (e.g. `E:\MyFiles\Worklog`) — external USB drive, secondary partition, SD card, etc. — the path didn't match any configured scope. Calls to `exists()`, `mkdir()`, `Database.load()`, and other filesystem operations threw a **"forbidden path"** error.
 
-When the saved workspace path resolved to a location outside the allowed scopes, calls to `exists()`, `mkdir()`, and other filesystem operations threw a "forbidden path" error on every relaunch — the app was stuck in an error loop.
+The same error also occurred for workspaces in `$APPDATA`, `$DESKTOP`, `$RESOURCE` before those scopes were added.
 
 ## Changes
 
 ### `src-tauri/capabilities/default.json`
 
-Added three missing scope variables to all filesystem operations (`write-text-file`, `read-text-file`, `read-dir`, `mkdir`, `exists`):
+Replaced all per-variable scope lists with a single catch-all `**` pattern for each filesystem operation (`write-text-file`, `read-text-file`, `read-dir`, `mkdir`, `exists`). This allows the user to choose **any local folder** regardless of drive letter.
 
-- **`$RESOURCE/**/*`** — Covers workspaces stored alongside `worklog.exe` (the user-reported workaround)
-- **`$APPDATA/**/*`** — Covers workspaces in `AppData\Roaming`
-- **`$DESKTOP/**/*`** — Covers workspaces on the desktop (common choice)
+**Before:**
+```json
+{"path": "$DOCUMENT/**/*"},
+{"path": "$HOME/**/*"},
+{"path": "$APPDATA/**/*"},
+{"path": "$RESOURCE/**/*"},
+{"path": "$DESKTOP/**/*"}
+```
+
+**After:**
+```json
+{"path": "**"}
+```
 
 ### `src/lib/hooks/workspace.svelte.ts`
 
-Added two layers of resilience for unrecoverable path errors:
+**1. Path normalization** — Added `normalizePath()` that converts Windows backslashes to forward slashes. Applied at all three entry points:
+   - **Dialog result** in `pick()` — the OS file picker returns native paths (`E:\MyFiles\Worklog`)
+   - **Saved path** in `init()` — localStorage may contain backslash paths from previous sessions
+   - **`open_workspace()` body** — safety net for any callers that might pass raw paths
+
+   This prevents mixed-separator paths like `E:\MyFiles\Worklog/.worklog` which could confuse Tauri's filesystem scope matching.
+
+**2. Two layers of resilience** for unrecoverable path errors:
 
 1. **`classifyWorkspaceError()`** — Translates raw Tauri FS errors (`forbidden`, `not allowed`, `permission denied`, `ENOSYS`) into a user-friendly message explaining the folder is inaccessible and suggesting a different location.
 
@@ -45,5 +56,6 @@ Added two layers of resilience for unrecoverable path errors:
 | Workspace on Desktop | "forbidden path" error on relaunch | Works normally |
 | Workspace alongside worklog.exe | Works (workaround) | Works |
 | Workspace in AppData | "forbidden path" error on relaunch | Works normally |
+| Workspace on **external drive** (E:, D:, etc.) | "forbidden path" error (no scope matched) | ✅ **Fixed** — `**` covers any drive |
 | Workspace on now-unplugged drive | Stuck error screen on every relaunch | Saved path cleared; shows selector with clear message |
 | Workspace in restricted system dir | Raw error message shown | Friendly message: "choose a different folder" |

--- a/packages/worklog/src-tauri/Cargo.lock
+++ b/packages/worklog/src-tauri/Cargo.lock
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "worklog"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/worklog/src-tauri/capabilities/default.json
+++ b/packages/worklog/src-tauri/capabilities/default.json
@@ -29,19 +29,7 @@
       "identifier": "fs:allow-write-text-file",
       "allow": [
         {
-          "path": "$DOCUMENT/**/*"
-        },
-        {
-          "path": "$HOME/**/*"
-        },
-        {
-          "path": "$APPDATA/**/*"
-        },
-        {
-          "path": "$RESOURCE/**/*"
-        },
-        {
-          "path": "$DESKTOP/**/*"
+          "path": "**"
         }
       ]
     },
@@ -49,19 +37,7 @@
       "identifier": "fs:allow-read-text-file",
       "allow": [
         {
-          "path": "$DOCUMENT/**/*"
-        },
-        {
-          "path": "$HOME/**/*"
-        },
-        {
-          "path": "$APPDATA/**/*"
-        },
-        {
-          "path": "$RESOURCE/**/*"
-        },
-        {
-          "path": "$DESKTOP/**/*"
+          "path": "**"
         }
       ]
     },
@@ -69,19 +45,7 @@
       "identifier": "fs:allow-read-dir",
       "allow": [
         {
-          "path": "$DOCUMENT/**/*"
-        },
-        {
-          "path": "$HOME/**/*"
-        },
-        {
-          "path": "$APPDATA/**/*"
-        },
-        {
-          "path": "$RESOURCE/**/*"
-        },
-        {
-          "path": "$DESKTOP/**/*"
+          "path": "**"
         }
       ]
     },
@@ -89,19 +53,7 @@
       "identifier": "fs:allow-mkdir",
       "allow": [
         {
-          "path": "$DOCUMENT/**/*"
-        },
-        {
-          "path": "$HOME/**/*"
-        },
-        {
-          "path": "$APPDATA/**/*"
-        },
-        {
-          "path": "$RESOURCE/**/*"
-        },
-        {
-          "path": "$DESKTOP/**/*"
+          "path": "**"
         }
       ]
     },
@@ -109,19 +61,7 @@
       "identifier": "fs:allow-exists",
       "allow": [
         {
-          "path": "$DOCUMENT/**/*"
-        },
-        {
-          "path": "$HOME/**/*"
-        },
-        {
-          "path": "$APPDATA/**/*"
-        },
-        {
-          "path": "$RESOURCE/**/*"
-        },
-        {
-          "path": "$DESKTOP/**/*"
+          "path": "**"
         }
       ]
     },

--- a/packages/worklog/src/lib/hooks/workspace.svelte.ts
+++ b/packages/worklog/src/lib/hooks/workspace.svelte.ts
@@ -42,6 +42,11 @@ type WorkspaceStatus =
     | 'ready'       // fully loaded, show board view
     | 'error'       // something went wrong
 
+/** Normalize Windows backslashes to forward slashes for consistent path handling. */
+function normalizePath(p: string): string {
+    return p.replaceAll('\\', '/');
+}
+
 /** Classify common Tauri errors into user-friendly messages. */
 function classifyWorkspaceError(raw: string): string {
     // Tauri filesystem scope violations (Windows "forbidden path")
@@ -80,9 +85,10 @@ export function getWorkspace() {
                     return;
                 }
 
-                await open_workspace(saved);
+                const resolved = normalizePath(saved);
+                await open_workspace(resolved);
 
-                if (_path !== saved) {
+                if (_path !== resolved) {
                     _path = null;
                     _meta = null;
                     clearSavedWorkspacePath();
@@ -123,18 +129,19 @@ export function getWorkspace() {
             const { open } = await import('@tauri-apps/plugin-dialog');
             const selected = await open({ directory: true, multiple: false });
             if (!selected) return; // user cancelled
-            await open_workspace(selected as string);
+            await open_workspace(normalizePath(selected as string));
         } catch (e) {
             _error = String(e);
             _status = 'error';
         }
     }
 
-    async function open_workspace(path: string) {
+    async function open_workspace(rawPath: string) {
         try {
             _status = 'loading';
             _error = null;
 
+            const path = normalizePath(rawPath);
             const db = await getDb(path);
             await runMigrations(db);
             await WorkspaceRepo.initWorkspace(db, path.split('/').pop() ?? 'My Workspace');


### PR DESCRIPTION
#88 
This pull request addresses major issues with filesystem access on Windows 11, especially when users select workspace folders on drives other than C: or outside standard user directories. It updates the Tauri filesystem scope configuration to allow access to any local folder, normalizes path handling to avoid separator mismatches, and improves error messaging for inaccessible paths. These changes ensure users can select workspaces on any drive and receive clearer feedback if something goes wrong.

**Filesystem access improvements:**

* Replaced all per-variable filesystem access scopes in `default.json` with a single catch-all `"**"` pattern for each operation, allowing workspace folders on any drive or location.
* Updated submodule `aur` to a new commit, likely to pull in related upstream fixes or dependencies.

**Path handling and resilience:**

* Added `normalizePath()` in `workspace.svelte.ts` to consistently convert Windows backslashes to forward slashes, applied at all entry points where a workspace path is set or used. [[1]](diffhunk://#diff-c8b096a41c8ea3188ea34d59548c7f2b305594a792dc1f3049a9a90bb599eac4R45-R49) [[2]](diffhunk://#diff-c8b096a41c8ea3188ea34d59548c7f2b305594a792dc1f3049a9a90bb599eac4L83-R91) [[3]](diffhunk://#diff-c8b096a41c8ea3188ea34d59548c7f2b305594a792dc1f3049a9a90bb599eac4L126-R144)

**User experience and documentation:**

* Improved error handling to translate raw filesystem errors into user-friendly messages and clear saved workspace paths if the location is no longer accessible.
* Updated documentation to reflect the new catch-all scope, describe the previous limitations, and clarify the improved behavior for workspaces on external drives and other locations. [[1]](diffhunk://#diff-513fec6b495bcd3af0a9187041e05a7356349543cf8fa0343c196b49d8c81894L11-R46) [[2]](diffhunk://#diff-513fec6b495bcd3af0a9187041e05a7356349543cf8fa0343c196b49d8c81894R59)