### PR TITLE
Add Docs tab for markdown notes in board detail page

### DIFF
--- a/packages/worklog/PLAN-board-markdown-integration.md
+++ b/packages/worklog/PLAN-board-markdown-integration.md
@@ -1,0 +1,162 @@
+# Plan: Board Docs Tab — Markdown Notes per Board
+
+> **Goal**: Add a **Docs** tab on each board where users can browse, create, and edit markdown note files — stored as real `.md` files on the filesystem.
+>
+> **Principle**: Start small. A file tree + a textarea with live preview. No new deps. No schema changes.
+
+---
+
+## Current State
+
+The board detail page (`/workspace/[board_id]`) has 4 tabs:
+
+| Tab | Component | Mode |
+|-----|-----------|------|
+| Kanban | `KanbanBoard` | visual |
+| Table | `TableView` | grid |
+| Timeline | `GanttView` | planning |
+| Calendar | `CalendarView` | calendar |
+
+There is currently **no docs/notes tab**. The user wants a 5th tab where markdown files live alongside each board.
+
+---
+
+## Storage Strategy
+
+Markdown files are stored **on the filesystem**, not in SQLite. This is the git-native approach — the files are plain text, diffable, and editable outside the app.
+
+```
+.worklog/
+├── worklog.db                    # SQLite (existing)
+├── sync/                         # sync artifacts (existing)
+└── boards/
+    └── <board_id>/
+        └── docs/                 # ← NEW: user's markdown files
+            ├── README.md
+            ├── architecture.md
+            └── meeting-notes/
+                └── 2026-06-17.md
+```
+
+**Why `.worklog/boards/<board_id>/docs/`**:
+- Scoped per board, naturally grouped by board ID
+- Plain `.md` files — zero lock-in, viewable in any editor
+- Tracked by git if the workspace is a git repo (user opt-in by committing them)
+- No schema migration needed — zero DB changes
+
+---
+
+## Phase 0 — Docs Tab + File Tree + Read-Only Preview (the MVP)
+
+**Deliverable**: A 5th tab "Docs" appears on the board detail page. Shows a **file tree** of `.md` files inside `.worklog/boards/<board_id>/docs/`. Clicking a file renders it as HTML.
+
+**Files to create**:
+- `src/lib/hooks/board-docs.svelte.ts` — hook for listing/reading `.md` files via Tauri FS plugin
+- `src/lib/components/app/board/board-docs.svelte` — tab component (file tree sidebar + content area)
+
+**Files to update**:
+- `src/routes/workspace/[board_id]/+page.svelte` — add 5th tab "Docs", wire it in
+
+**What it looks like**:
+```
+┌──────────────────────────────────────────────────┐
+│ [Kanban] [Table] [Timeline] [Calendar] [📄 Docs] │  ← new tab
+├──────────────┬───────────────────────────────────┤
+│ 📁 docs/     │  # Architecture                   │
+│  ├ README.md │                                   │
+│  ├ arch.md   │  This document describes the...   │
+│  └ meeting.. │                                   │
+│              │  ## Overview                      │
+│              │                                   │
+│              │  The system uses...                │
+└──────────────┴───────────────────────────────────┘
+```
+
+**File tree** (left, ~220px):
+- Recursively lists `.md` files in the board's docs directory
+- Folders are collapsible
+- Click a file to select it
+
+**Content area** (right):
+- Renders selected file as HTML via a simple inline markdown-to-HTML converter
+- No npm dependency — just handle: `#` headings, `**bold**`, `- list`, `` `code` ``, `[links](url)`, blank-line paragraphs
+- If no file selected, show a welcome/empty state
+
+**If docs directory doesn't exist yet**:
+- Show empty state: "No docs yet — create your first note"
+- A button "New Note" that creates a blank `README.md`
+
+---
+
+## Phase 1 — Inline Editor (edit .md files)
+
+**Deliverable**: Clicking a file switches to split-pane mode: textarea (left) + rendered preview (right). Auto-saves on blur or Ctrl+S.
+
+**Changes**:
+- `board-docs.svelte` — add edit mode toggle, textarea, save handler
+- `board-docs.svelte.ts` — add `writeDoc()` function (writes to filesystem via Tauri)
+
+**UX**:
+- Default: read-only rendered view
+- Click "Edit" button (or press `e`) → split pane
+- Left: `<textarea>` with the raw markdown content
+- Right: live rendered preview, updates as you type
+- `Ctrl+S` or blur → save to filesystem
+- "Done" or `Esc` exits edit mode
+
+---
+
+## Phase 2 — Create, Rename, Delete Notes
+
+**Deliverable**: File tree gains toolbar actions: New Note, New Folder, Rename, Delete.
+
+**Changes**:
+- `board-docs.svelte` — add toolbar buttons / context menu
+- `board-docs.svelte.ts` — add `createDoc()`, `deleteDoc()`, `renameDoc()` functions
+
+---
+
+## Phase 3 — Polish (Deferred)
+
+- Drag-and-drop file reordering in tree
+- Folder collapse/expand persistence
+- File search within docs
+- Auto-create `README.md` when board is created (optional)
+
+Only if Phases 0-2 prove useful.
+
+---
+
+## Non-Goals (Explicitly Out of Scope)
+
+- **No schema changes** — markdown lives on the filesystem, not in SQLite
+- **No npm markdown parser** — inline rendering keeps deps at zero
+- **No rich text editor** — plain textarea + preview is the ceiling for now
+- **No sync integration** — these files are already on the filesystem, accessible to git directly
+- **No board-delete cleanup** — orphaned docs dirs are harmless; can add later
+
+---
+
+## File Manifest
+
+| Phase | File | Action |
+|-------|------|--------|
+| 0 | `src/lib/hooks/board-docs.svelte.ts` | **Create** — FS listing/reading hook |
+| 0 | `src/lib/components/app/board/board-docs.svelte` | **Create** — file tree + preview tab |
+| 0 | `src/routes/workspace/[board_id]/+page.svelte` | **Update** — add 5th tab "Docs" |
+| 1 | `src/lib/hooks/board-docs.svelte.ts` | **Update** — add `writeDoc()` |
+| 1 | `src/lib/components/app/board/board-docs.svelte` | **Update** — add split-pane editor |
+| 2 | `src/lib/hooks/board-docs.svelte.ts` | **Update** — add `createDoc`, `deleteDoc`, `renameDoc` |
+| 2 | `src/lib/components/app/board/board-docs.svelte` | **Update** — add file tree toolbar/context menu |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Tauri FS plugin unavailable in browser dev mode | Lazy dynamic import with try/catch; fallback to mock data in dev |
+| User deletes docs directory externally | File tree gracefully shows empty state + "Create first note" |
+| Large directory trees slow to list | Recursive listing initially; virtual scroll if needed later |
+| Markdown rendering quality | Inline renderer handles 80% of cases. If inadequate, swap for a lightweight marked.js — still no heavy dep |
+| Orphaned docs dirs after board deletion | Harmless — just empty folders. Cleanup can be a follow-up |

--- a/packages/worklog/src-tauri/capabilities/default.json
+++ b/packages/worklog/src-tauri/capabilities/default.json
@@ -58,6 +58,22 @@
       ]
     },
     {
+      "identifier": "fs:allow-rename",
+      "allow": [
+        {
+          "path": "**"
+        }
+      ]
+    },
+    {
+      "identifier": "fs:allow-remove",
+      "allow": [
+        {
+          "path": "**"
+        }
+      ]
+    },
+    {
       "identifier": "fs:allow-exists",
       "allow": [
         {

--- a/packages/worklog/src/lib/components/app/board/board-docs.svelte
+++ b/packages/worklog/src/lib/components/app/board/board-docs.svelte
@@ -51,18 +51,55 @@
     // Show "Saved!" feedback briefly after save
     function flashSaved() {
         savedIndicator = true;
-        setTimeout(() => { savedIndicator = false; }, 1500);
+        setTimeout(() => {
+            savedIndicator = false;
+        }, 1500);
     }
 
     // ── Formatting toolbar & slash commands ─────────────────────────────────
     const FORMAT_ACTIONS = [
-        { id: 'bold',      label: 'B',    title: 'Bold (Ctrl+B)',       action: () => insertWrap('**', '**') },
-        { id: 'h1',        label: 'H1',   title: 'Heading 1',    action: () => insertLine('# ') },
-        { id: 'h2',        label: 'H2',   title: 'Heading 2',    action: () => insertLine('## ') },
-        { id: 'h3',        label: 'H3',   title: 'Heading 3',    action: () => insertLine('### ') },
-        { id: 'bullet',    label: '\u2022', title: 'Bullet list', action: () => insertLine('- ') },
-        { id: 'numbered',  label: '1.',   title: 'Numbered list', action: () => insertLine('1. ') },
-        { id: 'codeblock', label: '<>',   title: 'Code block',    action: () => insertCodeBlock() },
+        {
+            id: "bold",
+            label: "B",
+            title: "Bold (Ctrl+B)",
+            action: () => insertWrap("**", "**"),
+        },
+        {
+            id: "h1",
+            label: "H1",
+            title: "Heading 1",
+            action: () => insertLine("# "),
+        },
+        {
+            id: "h2",
+            label: "H2",
+            title: "Heading 2",
+            action: () => insertLine("## "),
+        },
+        {
+            id: "h3",
+            label: "H3",
+            title: "Heading 3",
+            action: () => insertLine("### "),
+        },
+        {
+            id: "bullet",
+            label: "\u2022",
+            title: "Bullet list",
+            action: () => insertLine("- "),
+        },
+        {
+            id: "numbered",
+            label: "1.",
+            title: "Numbered list",
+            action: () => insertLine("1. "),
+        },
+        {
+            id: "codeblock",
+            label: "<>",
+            title: "Code block",
+            action: () => insertCodeBlock(),
+        },
     ] as const;
 
     interface SlashCmd {
@@ -73,34 +110,72 @@
     }
 
     const SLASH_COMMANDS: SlashCmd[] = [
-        { id: 'bold',      label: 'Bold',         match: 'bold b',        action: () => insertWrap('**', '**') },
-        { id: 'h1',        label: 'Heading 1',    match: 'h1 heading 1',  action: () => insertLine('# ') },
-        { id: 'h2',        label: 'Heading 2',    match: 'h2 heading 2',  action: () => insertLine('## ') },
-        { id: 'h3',        label: 'Heading 3',    match: 'h3 heading 3',  action: () => insertLine('### ') },
-        { id: 'bullet',    label: 'Bullet list',  match: 'bullet ul -',   action: () => insertLine('- ') },
-        { id: 'numbered',  label: 'Numbered list', match: 'numbered ol 1.', action: () => insertLine('1. ') },
-        { id: 'codeblock', label: 'Code block',   match: 'code block ```', action: () => insertCodeBlock() },
+        {
+            id: "bold",
+            label: "Bold",
+            match: "bold b",
+            action: () => insertWrap("**", "**"),
+        },
+        {
+            id: "h1",
+            label: "Heading 1",
+            match: "h1 heading 1",
+            action: () => insertLine("# "),
+        },
+        {
+            id: "h2",
+            label: "Heading 2",
+            match: "h2 heading 2",
+            action: () => insertLine("## "),
+        },
+        {
+            id: "h3",
+            label: "Heading 3",
+            match: "h3 heading 3",
+            action: () => insertLine("### "),
+        },
+        {
+            id: "bullet",
+            label: "Bullet list",
+            match: "bullet ul -",
+            action: () => insertLine("- "),
+        },
+        {
+            id: "numbered",
+            label: "Numbered list",
+            match: "numbered ol 1.",
+            action: () => insertLine("1. "),
+        },
+        {
+            id: "codeblock",
+            label: "Code block",
+            match: "code block ```",
+            action: () => insertCodeBlock(),
+        },
     ];
 
     // Slash menu state
     let slashOpen = $state(false);
-    let slashSearch = $state('');
+    let slashSearch = $state("");
     let slashIndex = $state(0);
     let slashMenuEl = $state<HTMLElement | null>(null);
 
     const slashFiltered = $derived(
         slashOpen && slashSearch
-            ? SLASH_COMMANDS.filter(c =>
-                  c.match.toLowerCase().includes(slashSearch.toLowerCase())
+            ? SLASH_COMMANDS.filter((c) =>
+                  c.match.toLowerCase().includes(slashSearch.toLowerCase()),
               )
-            : SLASH_COMMANDS
+            : SLASH_COMMANDS,
     );
 
     function openSlashMenu(cursor: number) {
         // Extract search term: text between '/' and cursor
         const before = draftContent.slice(0, cursor);
-        const slashIdx = before.lastIndexOf('/');
-        if (slashIdx === -1) { slashOpen = false; return; }
+        const slashIdx = before.lastIndexOf("/");
+        if (slashIdx === -1) {
+            slashOpen = false;
+            return;
+        }
         const term = before.slice(slashIdx + 1);
 
         slashSearch = term;
@@ -110,7 +185,7 @@
 
     function closeSlashMenu() {
         slashOpen = false;
-        slashSearch = '';
+        slashSearch = "";
         slashIndex = 0;
     }
 
@@ -119,7 +194,7 @@
         if (!ta) return;
         const cursor = ta.selectionStart;
         const before = draftContent.slice(0, cursor);
-        const slashIdx = before.lastIndexOf('/');
+        const slashIdx = before.lastIndexOf("/");
         const afterSlash = before.slice(slashIdx);
         const endOfWord = afterSlash.match(/^\/\w*/)?.[0]?.length ?? 0;
         const start = slashIdx;
@@ -138,23 +213,23 @@
     function handleSlashKeydown(e: KeyboardEvent) {
         if (!slashOpen) return;
 
-        if (e.key === 'ArrowDown') {
+        if (e.key === "ArrowDown") {
             e.preventDefault();
             slashIndex = Math.min(slashIndex + 1, slashFiltered.length - 1);
             return;
         }
-        if (e.key === 'ArrowUp') {
+        if (e.key === "ArrowUp") {
             e.preventDefault();
             slashIndex = Math.max(slashIndex - 1, 0);
             return;
         }
-        if (e.key === 'Enter' || e.key === 'Tab') {
+        if (e.key === "Enter" || e.key === "Tab") {
             e.preventDefault();
             const cmd = slashFiltered[slashIndex];
             if (cmd) applySlashCommand(cmd);
             return;
         }
-        if (e.key === 'Escape') {
+        if (e.key === "Escape") {
             e.preventDefault();
             closeSlashMenu();
             return;
@@ -166,16 +241,22 @@
         const ta = editDraftEl;
         if (!ta) return;
         const cursor = ta.selectionStart;
-        if (cursor === 0) { closeSlashMenu(); return; }
+        if (cursor === 0) {
+            closeSlashMenu();
+            return;
+        }
         const charBefore = draftContent[cursor - 1];
-        if (charBefore === '/') {
+        if (charBefore === "/") {
             openSlashMenu(cursor);
         } else if (slashOpen) {
             const before = draftContent.slice(0, cursor);
-            const slashIdx = before.lastIndexOf('/');
-            if (slashIdx === -1) { closeSlashMenu(); return; }
+            const slashIdx = before.lastIndexOf("/");
+            if (slashIdx === -1) {
+                closeSlashMenu();
+                return;
+            }
             const term = before.slice(slashIdx + 1);
-            if (term.includes(' ') || term.includes('\n')) {
+            if (term.includes(" ") || term.includes("\n")) {
                 closeSlashMenu();
             } else {
                 slashSearch = term;
@@ -194,9 +275,12 @@
         if (!ta) return;
         const start = ta.selectionStart;
         const end = ta.selectionEnd;
-        const selected = draftContent.slice(start, end) || 'text';
+        const selected = draftContent.slice(start, end) || "text";
         const replacement = `${before}${selected}${after}`;
-        draftContent = draftContent.slice(0, start) + replacement + draftContent.slice(end);
+        draftContent =
+            draftContent.slice(0, start) +
+            replacement +
+            draftContent.slice(end);
         requestAnimationFrame(() => {
             ta.focus();
             ta.selectionStart = start + before.length;
@@ -210,9 +294,12 @@
         const start = ta.selectionStart;
         // Find start of current line
         const before = draftContent.slice(0, start);
-        const lineStart = before.lastIndexOf('\n') + 1;
+        const lineStart = before.lastIndexOf("\n") + 1;
         const insertion = `${prefix}`;
-        draftContent = draftContent.slice(0, lineStart) + insertion + draftContent.slice(lineStart);
+        draftContent =
+            draftContent.slice(0, lineStart) +
+            insertion +
+            draftContent.slice(lineStart);
         requestAnimationFrame(() => {
             ta.focus();
             const newCursor = lineStart + insertion.length;
@@ -226,9 +313,12 @@
         if (!ta) return;
         const start = ta.selectionStart;
         const end = ta.selectionEnd;
-        const selected = draftContent.slice(start, end) || 'code';
-        const replacement = '```\n' + selected + '\n```';
-        draftContent = draftContent.slice(0, start) + replacement + draftContent.slice(end);
+        const selected = draftContent.slice(start, end) || "code";
+        const replacement = "```\n" + selected + "\n```";
+        draftContent =
+            draftContent.slice(0, start) +
+            replacement +
+            draftContent.slice(end);
         requestAnimationFrame(() => {
             ta.focus();
             const newCursor = start + replacement.length;
@@ -318,15 +408,15 @@
 
     // ── Create new note (inline filename input) ────────────────────────────
     let creatingFile = $state(false);
-    let newFileName = $state('');
+    let newFileName = $state("");
     let newFileInputEl = $state<HTMLInputElement | null>(null);
 
     function startCreateFile() {
         creatingFile = true;
-        newFileName = '';
+        newFileName = "";
         // If docs dir doesn't exist yet, suggest README.md as default
         if (!hasDocsDir) {
-            newFileName = 'README.md';
+            newFileName = "README.md";
         }
         requestAnimationFrame(() => {
             newFileInputEl?.focus();
@@ -342,14 +432,14 @@
         }
 
         clearError();
-        const fileName = name.endsWith('.md') ? name : `${name}.md`;
+        const fileName = name.endsWith(".md") ? name : `${name}.md`;
         creatingFile = false;
         try {
             const result = await createDocFile(
                 workspacePath,
                 boardId,
                 fileName,
-                `# ${fileName.replace('.md', '')}\n\n`,
+                `# ${fileName.replace(".md", "")}\n\n`,
             );
             if (result) {
                 await loadFiles();
@@ -358,7 +448,9 @@
                     selectedPath = newEntry.relativePath;
                 }
             } else {
-                showError('Failed to create file. Check that Tauri FS can write to the workspace and try again.');
+                showError(
+                    "Failed to create file. Check that Tauri FS can write to the workspace and try again.",
+                );
             }
         } catch (e) {
             showError(String(e));
@@ -366,10 +458,10 @@
     }
 
     function handleNewFileKeydown(e: KeyboardEvent) {
-        if (e.key === 'Enter') {
+        if (e.key === "Enter") {
             e.preventDefault();
             void confirmCreateFile();
-        } else if (e.key === 'Escape') {
+        } else if (e.key === "Escape") {
             e.preventDefault();
             creatingFile = false;
         }
@@ -453,19 +545,22 @@
             return;
         }
         // Arrow keys in slash menu
-        if (slashOpen && (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Tab')) {
+        if (
+            slashOpen &&
+            (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Tab")
+        ) {
             handleSlashKeydown(e);
             return;
         }
         // Enter in slash menu
-        if (slashOpen && e.key === 'Enter') {
+        if (slashOpen && e.key === "Enter") {
             handleSlashKeydown(e);
             return;
         }
         // Ctrl+B → bold
         if ((e.ctrlKey || e.metaKey) && e.key === "b") {
             e.preventDefault();
-            insertWrap('**', '**');
+            insertWrap("**", "**");
             return;
         }
     }
@@ -749,13 +844,13 @@
                     />
                 </div>
             {:else}
-            <Button
-                kind="primary"
-                icon={DocumentAdd}
-                onclick={startCreateFile}
-            >
-                New Note
-            </Button>
+                <Button
+                    kind="primary"
+                    icon={DocumentAdd}
+                    onclick={startCreateFile}
+                >
+                    New Note
+                </Button>
             {/if}
         </div>
     {:else}
@@ -1050,8 +1145,8 @@
                                     class="editor-toolbar-btn"
                                     onclick={fmt.action}
                                     title={fmt.title}
-                                    aria-label={fmt.title}
-                                >{fmt.label}</button>
+                                    aria-label={fmt.title}>{fmt.label}</button
+                                >
                             {/each}
                         </div>
                         <div class="board-docs-editor-panes">
@@ -1068,14 +1163,23 @@
                                         {#each slashFiltered as cmd, i (cmd.id)}
                                             <button
                                                 class="slash-menu-item"
-                                                class:slash-menu-item--active={i === slashIndex}
+                                                class:slash-menu-item--active={i ===
+                                                    slashIndex}
                                                 role="option"
                                                 aria-selected={i === slashIndex}
-                                                onclick={() => applySlashCommand(cmd)}
-                                                onmouseenter={() => (slashIndex = i)}
+                                                onclick={() =>
+                                                    applySlashCommand(cmd)}
+                                                onmouseenter={() =>
+                                                    (slashIndex = i)}
                                             >
-                                                <span class="slash-menu-label">{cmd.label}</span>
-                                                <span class="slash-menu-hint">/{cmd.match.split(' ')[0]}</span>
+                                                <span class="slash-menu-label"
+                                                    >{cmd.label}</span
+                                                >
+                                                <span class="slash-menu-hint"
+                                                    >/{cmd.match.split(
+                                                        " ",
+                                                    )[0]}</span
+                                                >
                                             </button>
                                         {/each}
                                     </div>
@@ -1551,8 +1655,10 @@
         color: var(--cds-text-02);
         cursor: pointer;
         border-radius: 3px;
-        transition: background 0.1s ease, color 0.1s ease;
-        font-family: 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace;
+        transition:
+            background 0.1s ease,
+            color 0.1s ease;
+        font-family: "IBM Plex Mono", "SF Mono", "Fira Code", monospace;
     }
 
     .editor-toolbar-btn:hover {
@@ -1645,7 +1751,7 @@
     .slash-menu-hint {
         font-size: 0.6875rem;
         color: var(--cds-text-03);
-        font-family: 'IBM Plex Mono', 'SF Mono', monospace;
+        font-family: "IBM Plex Mono", "SF Mono", monospace;
         margin-left: 1rem;
     }
 
@@ -1676,9 +1782,15 @@
     }
 
     @keyframes docs-saved-fade {
-        0% { opacity: 1; }
-        70% { opacity: 1; }
-        100% { opacity: 0; }
+        0% {
+            opacity: 1;
+        }
+        70% {
+            opacity: 1;
+        }
+        100% {
+            opacity: 0;
+        }
     }
 
     @keyframes docs-saving-pulse {

--- a/packages/worklog/src/lib/components/app/board/board-docs.svelte
+++ b/packages/worklog/src/lib/components/app/board/board-docs.svelte
@@ -4,8 +4,10 @@
         DocumentAdd,
         Edit,
         Folder,
+        FolderAdd,
         ChevronRight,
         ChevronDown,
+        TrashCan,
         Notebook,
     } from "carbon-icons-svelte";
     import { Button } from "carbon-components-svelte";
@@ -14,7 +16,11 @@
         readDocFile,
         writeDocFile,
         createDocFile,
+        deleteDocFile,
+        renameDocFile,
+        createDocFolder,
         docsDirectoryExists,
+        docsDir,
         type DocFileEntry,
     } from "$lib/hooks/board-docs.svelte";
 
@@ -40,6 +46,213 @@
     let pendingSave = $state(false);
     let editDraftEl = $state<HTMLTextAreaElement | null>(null);
     let saving = $state(false);
+    let savedIndicator = $state(false);
+
+    // Show "Saved!" feedback briefly after save
+    function flashSaved() {
+        savedIndicator = true;
+        setTimeout(() => { savedIndicator = false; }, 1500);
+    }
+
+    // ── Formatting toolbar & slash commands ─────────────────────────────────
+    const FORMAT_ACTIONS = [
+        { id: 'bold',      label: 'B',    title: 'Bold (Ctrl+B)',       action: () => insertWrap('**', '**') },
+        { id: 'h1',        label: 'H1',   title: 'Heading 1',    action: () => insertLine('# ') },
+        { id: 'h2',        label: 'H2',   title: 'Heading 2',    action: () => insertLine('## ') },
+        { id: 'h3',        label: 'H3',   title: 'Heading 3',    action: () => insertLine('### ') },
+        { id: 'bullet',    label: '\u2022', title: 'Bullet list', action: () => insertLine('- ') },
+        { id: 'numbered',  label: '1.',   title: 'Numbered list', action: () => insertLine('1. ') },
+        { id: 'codeblock', label: '<>',   title: 'Code block',    action: () => insertCodeBlock() },
+    ] as const;
+
+    interface SlashCmd {
+        id: string;
+        label: string;
+        match: string;
+        action: () => void;
+    }
+
+    const SLASH_COMMANDS: SlashCmd[] = [
+        { id: 'bold',      label: 'Bold',         match: 'bold b',        action: () => insertWrap('**', '**') },
+        { id: 'h1',        label: 'Heading 1',    match: 'h1 heading 1',  action: () => insertLine('# ') },
+        { id: 'h2',        label: 'Heading 2',    match: 'h2 heading 2',  action: () => insertLine('## ') },
+        { id: 'h3',        label: 'Heading 3',    match: 'h3 heading 3',  action: () => insertLine('### ') },
+        { id: 'bullet',    label: 'Bullet list',  match: 'bullet ul -',   action: () => insertLine('- ') },
+        { id: 'numbered',  label: 'Numbered list', match: 'numbered ol 1.', action: () => insertLine('1. ') },
+        { id: 'codeblock', label: 'Code block',   match: 'code block ```', action: () => insertCodeBlock() },
+    ];
+
+    // Slash menu state
+    let slashOpen = $state(false);
+    let slashSearch = $state('');
+    let slashIndex = $state(0);
+    let slashMenuEl = $state<HTMLElement | null>(null);
+
+    const slashFiltered = $derived(
+        slashOpen && slashSearch
+            ? SLASH_COMMANDS.filter(c =>
+                  c.match.toLowerCase().includes(slashSearch.toLowerCase())
+              )
+            : SLASH_COMMANDS
+    );
+
+    function openSlashMenu(cursor: number) {
+        // Extract search term: text between '/' and cursor
+        const before = draftContent.slice(0, cursor);
+        const slashIdx = before.lastIndexOf('/');
+        if (slashIdx === -1) { slashOpen = false; return; }
+        const term = before.slice(slashIdx + 1);
+
+        slashSearch = term;
+        slashOpen = true;
+        slashIndex = 0;
+    }
+
+    function closeSlashMenu() {
+        slashOpen = false;
+        slashSearch = '';
+        slashIndex = 0;
+    }
+
+    function applySlashCommand(cmd: SlashCmd) {
+        const ta = editDraftEl;
+        if (!ta) return;
+        const cursor = ta.selectionStart;
+        const before = draftContent.slice(0, cursor);
+        const slashIdx = before.lastIndexOf('/');
+        const afterSlash = before.slice(slashIdx);
+        const endOfWord = afterSlash.match(/^\/\w*/)?.[0]?.length ?? 0;
+        const start = slashIdx;
+        const end = start + endOfWord;
+        // Remove the /command text
+        draftContent = draftContent.slice(0, start) + draftContent.slice(end);
+        // Reset cursor to where / was
+        ta.selectionStart = start;
+        ta.selectionEnd = start;
+        // Run the formatting action
+        cmd.action();
+        closeSlashMenu();
+        requestAnimationFrame(() => ta?.focus());
+    }
+
+    function handleSlashKeydown(e: KeyboardEvent) {
+        if (!slashOpen) return;
+
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            slashIndex = Math.min(slashIndex + 1, slashFiltered.length - 1);
+            return;
+        }
+        if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            slashIndex = Math.max(slashIndex - 1, 0);
+            return;
+        }
+        if (e.key === 'Enter' || e.key === 'Tab') {
+            e.preventDefault();
+            const cmd = slashFiltered[slashIndex];
+            if (cmd) applySlashCommand(cmd);
+            return;
+        }
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            closeSlashMenu();
+            return;
+        }
+    }
+
+    // Detect slash in textarea input
+    function handleFormatInput() {
+        const ta = editDraftEl;
+        if (!ta) return;
+        const cursor = ta.selectionStart;
+        if (cursor === 0) { closeSlashMenu(); return; }
+        const charBefore = draftContent[cursor - 1];
+        if (charBefore === '/') {
+            openSlashMenu(cursor);
+        } else if (slashOpen) {
+            const before = draftContent.slice(0, cursor);
+            const slashIdx = before.lastIndexOf('/');
+            if (slashIdx === -1) { closeSlashMenu(); return; }
+            const term = before.slice(slashIdx + 1);
+            if (term.includes(' ') || term.includes('\n')) {
+                closeSlashMenu();
+            } else {
+                slashSearch = term;
+                slashIndex = 0;
+            }
+        }
+    }
+
+    // ── Markdown insertion helpers ─────────────────────────────────────────
+    function getTa(): HTMLTextAreaElement | null {
+        return editDraftEl;
+    }
+
+    function insertWrap(before: string, after: string) {
+        const ta = getTa();
+        if (!ta) return;
+        const start = ta.selectionStart;
+        const end = ta.selectionEnd;
+        const selected = draftContent.slice(start, end) || 'text';
+        const replacement = `${before}${selected}${after}`;
+        draftContent = draftContent.slice(0, start) + replacement + draftContent.slice(end);
+        requestAnimationFrame(() => {
+            ta.focus();
+            ta.selectionStart = start + before.length;
+            ta.selectionEnd = start + before.length + selected.length;
+        });
+    }
+
+    function insertLine(prefix: string) {
+        const ta = getTa();
+        if (!ta) return;
+        const start = ta.selectionStart;
+        // Find start of current line
+        const before = draftContent.slice(0, start);
+        const lineStart = before.lastIndexOf('\n') + 1;
+        const insertion = `${prefix}`;
+        draftContent = draftContent.slice(0, lineStart) + insertion + draftContent.slice(lineStart);
+        requestAnimationFrame(() => {
+            ta.focus();
+            const newCursor = lineStart + insertion.length;
+            ta.selectionStart = newCursor;
+            ta.selectionEnd = newCursor;
+        });
+    }
+
+    function insertCodeBlock() {
+        const ta = getTa();
+        if (!ta) return;
+        const start = ta.selectionStart;
+        const end = ta.selectionEnd;
+        const selected = draftContent.slice(start, end) || 'code';
+        const replacement = '```\n' + selected + '\n```';
+        draftContent = draftContent.slice(0, start) + replacement + draftContent.slice(end);
+        requestAnimationFrame(() => {
+            ta.focus();
+            const newCursor = start + replacement.length;
+            ta.selectionStart = newCursor;
+            ta.selectionEnd = newCursor;
+        });
+    }
+
+    // ── Error surfacing ────────────────────────────────────────────────────
+    let actionError = $state<string | null>(null);
+    let actionErrorTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function showError(msg: string) {
+        actionError = msg;
+        if (actionErrorTimer) clearTimeout(actionErrorTimer);
+        actionErrorTimer = setTimeout(() => {
+            actionError = null;
+        }, 6000);
+    }
+
+    function clearError() {
+        if (actionErrorTimer) clearTimeout(actionErrorTimer);
+        actionError = null;
+    }
 
     // ── Load file tree ─────────────────────────────────────────────────────
     async function loadFiles() {
@@ -103,28 +316,62 @@
         })();
     });
 
-    // ── Create new note ────────────────────────────────────────────────────
-    let creating = $state(false);
+    // ── Create new note (inline filename input) ────────────────────────────
+    let creatingFile = $state(false);
+    let newFileName = $state('');
+    let newFileInputEl = $state<HTMLInputElement | null>(null);
 
-    async function handleCreateNote() {
-        creating = true;
+    function startCreateFile() {
+        creatingFile = true;
+        newFileName = '';
+        // If docs dir doesn't exist yet, suggest README.md as default
+        if (!hasDocsDir) {
+            newFileName = 'README.md';
+        }
+        requestAnimationFrame(() => {
+            newFileInputEl?.focus();
+            newFileInputEl?.select();
+        });
+    }
+
+    async function confirmCreateFile() {
+        const name = newFileName.trim();
+        if (!name) {
+            creatingFile = false;
+            return;
+        }
+
+        clearError();
+        const fileName = name.endsWith('.md') ? name : `${name}.md`;
+        creatingFile = false;
         try {
             const result = await createDocFile(
                 workspacePath,
                 boardId,
-                "README.md",
-                `# ${boardId}\n\nNotes for this board.\n`,
+                fileName,
+                `# ${fileName.replace('.md', '')}\n\n`,
             );
             if (result) {
                 await loadFiles();
-                // Auto-select the new file
                 const newEntry = findEntry(files, result);
                 if (newEntry) {
                     selectedPath = newEntry.relativePath;
                 }
+            } else {
+                showError('Failed to create file. Check that Tauri FS can write to the workspace and try again.');
             }
-        } finally {
-            creating = false;
+        } catch (e) {
+            showError(String(e));
+        }
+    }
+
+    function handleNewFileKeydown(e: KeyboardEvent) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            void confirmCreateFile();
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            creatingFile = false;
         }
     }
 
@@ -154,6 +401,15 @@
         });
     }
 
+    // Global Ctrl+S handler (catches it even if textarea isn't focused)
+    function handleWindowKeydown(e: KeyboardEvent) {
+        if (!editing) return;
+        if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+            e.preventDefault();
+            void handleSave();
+        }
+    }
+
     async function handleSave() {
         if (!selectedPath || saving) return;
         saving = true;
@@ -166,6 +422,7 @@
             );
             if (saved) {
                 fileContent = draftContent;
+                flashSaved();
             }
         } finally {
             saving = false;
@@ -185,10 +442,30 @@
             void handleSave();
             return;
         }
-        // Esc → save & exit
+        // Esc → save & exit (only if slash menu is closed)
         if (e.key === "Escape") {
+            if (slashOpen) {
+                closeSlashMenu();
+                return;
+            }
             e.preventDefault();
             void exitEditMode();
+            return;
+        }
+        // Arrow keys in slash menu
+        if (slashOpen && (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Tab')) {
+            handleSlashKeydown(e);
+            return;
+        }
+        // Enter in slash menu
+        if (slashOpen && e.key === 'Enter') {
+            handleSlashKeydown(e);
+            return;
+        }
+        // Ctrl+B → bold
+        if ((e.ctrlKey || e.metaKey) && e.key === "b") {
+            e.preventDefault();
+            insertWrap('**', '**');
             return;
         }
     }
@@ -203,6 +480,130 @@
             });
         }
     });
+
+    // ── File management: rename ───────────────────────────────────────────
+    let renamingPath = $state<string | null>(null);
+    let renameValue = $state("");
+    let renameInputEl = $state<HTMLInputElement | null>(null);
+
+    function startRename(entry: DocFileEntry) {
+        if (editing) return;
+        renamingPath = entry.relativePath;
+        renameValue = entry.name;
+        requestAnimationFrame(() => {
+            renameInputEl?.focus();
+            renameInputEl?.select();
+        });
+    }
+
+    async function confirmRename() {
+        const oldPath = renamingPath;
+        if (!oldPath || !renameValue.trim()) {
+            renamingPath = null;
+            return;
+        }
+
+        const newName = renameValue.trim();
+        // Preserve extension for files (not dirs)
+        const isDir = oldPath === oldPath.replace(/\//g, "") ? false : true;
+        const finalName = isDir
+            ? newName
+            : newName.endsWith(".md")
+              ? newName
+              : `${newName}.md`;
+
+        renamingPath = null;
+        const result = await renameDocFile(
+            workspacePath,
+            boardId,
+            oldPath,
+            finalName,
+        );
+        if (result) {
+            // If the renamed file was selected, update selection
+            if (selectedPath === oldPath) {
+                selectedPath = result;
+            }
+            await loadFiles();
+        }
+    }
+
+    function cancelRename() {
+        renamingPath = null;
+    }
+
+    function handleRenameKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            void confirmRename();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            cancelRename();
+        }
+    }
+
+    // ── File management: delete ────────────────────────────────────────────
+    let deletingPath = $state<string | null>(null);
+
+    async function confirmDelete(entry: DocFileEntry) {
+        if (editing) return;
+        const confirmed = window.confirm(
+            `Delete "${entry.name}"?${entry.isDir ? " This will also remove all files inside." : ""}`,
+        );
+        if (!confirmed) return;
+
+        deletingPath = entry.relativePath;
+        try {
+            const deleted = await deleteDocFile(
+                workspacePath,
+                boardId,
+                entry.relativePath,
+            );
+            if (deleted) {
+                // If the deleted file was selected, clear selection
+                if (selectedPath === entry.relativePath) {
+                    selectedPath = null;
+                    fileContent = null;
+                }
+                await loadFiles();
+            }
+        } finally {
+            deletingPath = null;
+        }
+    }
+
+    // ── File management: create folder ─────────────────────────────────────
+    let creatingFolder = $state(false);
+    let newFolderValue = $state("");
+    let newFolderInputEl = $state<HTMLInputElement | null>(null);
+
+    function startCreateFolder() {
+        creatingFolder = true;
+        newFolderValue = "";
+        requestAnimationFrame(() => {
+            newFolderInputEl?.focus();
+        });
+    }
+
+    async function confirmCreateFolder() {
+        if (!newFolderValue.trim()) {
+            creatingFolder = false;
+            return;
+        }
+        creatingFolder = false;
+        await createDocFolder(workspacePath, boardId, newFolderValue.trim());
+        await loadFiles();
+    }
+
+    function handleNewFolderKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            void confirmCreateFolder();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            creatingFolder = false;
+        }
+    }
 
     // ── Folder toggle ──────────────────────────────────────────────────────
     function toggleFolder(relativePath: string) {
@@ -243,7 +644,7 @@
             if (headingMatch) {
                 closeParagraph();
                 const level = headingMatch[1].length;
-                const text = escapeHtml(inlineMarkdown(headingMatch[2]));
+                const text = inlineMarkdown(escapeHtml(headingMatch[2]));
                 htmlParts.push(`<h${level}>${text}</h${level}>`);
                 continue;
             }
@@ -252,7 +653,7 @@
             const listMatch = trimmed.match(/^[-*+]\s+(.+)$/);
             if (listMatch) {
                 closeParagraph();
-                const text = escapeHtml(inlineMarkdown(listMatch[1]));
+                const text = inlineMarkdown(escapeHtml(listMatch[1]));
                 htmlParts.push(`<li>${text}</li>`);
                 continue;
             }
@@ -271,7 +672,7 @@
             } else {
                 htmlParts.push("<br>");
             }
-            htmlParts.push(escapeHtml(inlineMarkdown(trimmed)));
+            htmlParts.push(inlineMarkdown(escapeHtml(trimmed)));
         }
 
         closeParagraph();
@@ -318,6 +719,8 @@
     }
 </script>
 
+<svelte:window onkeydown={handleWindowKeydown} />
+
 <div class="board-docs">
     {#if loading}
         <div class="board-docs-loading">
@@ -328,14 +731,32 @@
             <Notebook size={48} />
             <h2>No docs yet</h2>
             <p>Create your first markdown note for this board.</p>
+            {#if actionError}
+                <p class="board-docs-error-msg">{actionError}</p>
+            {/if}
+            {#if creatingFile}
+                <div class="board-docs-inline-create">
+                    <Document size={16} />
+                    <input
+                        bind:this={newFileInputEl}
+                        type="text"
+                        class="board-docs-inline-input"
+                        placeholder="filename.md"
+                        bind:value={newFileName}
+                        onkeydown={handleNewFileKeydown}
+                        onblur={confirmCreateFile}
+                        aria-label="New file name"
+                    />
+                </div>
+            {:else}
             <Button
                 kind="primary"
                 icon={DocumentAdd}
-                onclick={handleCreateNote}
-                disabled={creating}
+                onclick={startCreateFile}
             >
-                {creating ? "Creating..." : "New Note"}
+                New Note
             </Button>
+            {/if}
         </div>
     {:else}
         <div class="board-docs-layout">
@@ -343,17 +764,59 @@
             <aside class="board-docs-tree">
                 <div class="board-docs-tree-header">
                     <span class="board-docs-tree-title">Docs</span>
-                    <button
-                        class="board-docs-new-btn"
-                        onclick={handleCreateNote}
-                        disabled={creating}
-                        aria-label="Create new note"
-                        title="New note"
-                    >
-                        <DocumentAdd size={16} />
-                    </button>
+                    <div class="board-docs-tree-toolbar">
+                        <button
+                            class="board-docs-tree-toolbar-btn"
+                            onclick={startCreateFolder}
+                            aria-label="Create new folder"
+                            title="New folder"
+                        >
+                            <FolderAdd size={14} />
+                        </button>
+                        <button
+                            class="board-docs-tree-toolbar-btn"
+                            onclick={startCreateFile}
+                            aria-label="Create new note"
+                            title="New note"
+                        >
+                            <DocumentAdd size={14} />
+                        </button>
+                    </div>
                 </div>
+                {#if actionError}
+                    <div class="board-docs-error-bar">{actionError}</div>
+                {/if}
                 <nav class="board-docs-tree-list" aria-label="Document files">
+                    {#if creatingFile}
+                        <div class="tree-create-input">
+                            <Document size={14} />
+                            <input
+                                bind:this={newFileInputEl}
+                                type="text"
+                                class="tree-inline-input"
+                                placeholder="filename.md"
+                                bind:value={newFileName}
+                                onkeydown={handleNewFileKeydown}
+                                onblur={confirmCreateFile}
+                                aria-label="New file name"
+                            />
+                        </div>
+                    {/if}
+                    {#if creatingFolder}
+                        <div class="tree-create-input">
+                            <Folder size={14} />
+                            <input
+                                bind:this={newFolderInputEl}
+                                type="text"
+                                class="tree-inline-input"
+                                placeholder="folder name"
+                                bind:value={newFolderValue}
+                                onkeydown={handleNewFolderKeydown}
+                                onblur={confirmCreateFolder}
+                                aria-label="New folder name"
+                            />
+                        </div>
+                    {/if}
                     {#each files as entry (entry.relativePath)}
                         {#if entry.isDir}
                             <div class="tree-folder">
@@ -369,35 +832,136 @@
                                         <ChevronRight size={14} />
                                     {/if}
                                     <Folder size={14} />
-                                    <span>{entry.name}</span>
+                                    {#if renamingPath === entry.relativePath}
+                                        <input
+                                            bind:this={renameInputEl}
+                                            type="text"
+                                            class="tree-inline-input"
+                                            bind:value={renameValue}
+                                            onkeydown={handleRenameKeydown}
+                                            onblur={confirmRename}
+                                            onclick={(e) => e.stopPropagation()}
+                                            aria-label="Rename folder"
+                                        />
+                                    {:else}
+                                        <span>{entry.name}</span>
+                                    {/if}
                                 </button>
                                 {#if isExpanded(entry)}
                                     <div class="tree-folder-children">
                                         {#each entry.children as child (child.relativePath)}
-                                            <button
-                                                class="tree-file"
-                                                class:tree-file--selected={isSelected(
+                                            <!-- svelte-ignore a11y_click_events_have_key_events -->
+                                            <div
+                                                class="tree-file-row"
+                                                class:tree-file-row--selected={isSelected(
                                                     child,
                                                 )}
-                                                onclick={() =>
-                                                    selectFile(child)}
                                             >
-                                                <Document size={14} />
-                                                <span>{child.name}</span>
-                                            </button>
+                                                <button
+                                                    class="tree-file"
+                                                    onclick={() =>
+                                                        selectFile(child)}
+                                                >
+                                                    <Document size={14} />
+                                                    {#if renamingPath === child.relativePath}
+                                                        <input
+                                                            bind:this={
+                                                                renameInputEl
+                                                            }
+                                                            type="text"
+                                                            class="tree-inline-input"
+                                                            bind:value={
+                                                                renameValue
+                                                            }
+                                                            onkeydown={handleRenameKeydown}
+                                                            onblur={confirmRename}
+                                                            onclick={(e) =>
+                                                                e.stopPropagation()}
+                                                            aria-label="Rename file"
+                                                        />
+                                                    {:else}
+                                                        <span>{child.name}</span
+                                                        >
+                                                    {/if}
+                                                </button>
+                                                <div class="tree-file-actions">
+                                                    <button
+                                                        class="tree-action-btn"
+                                                        onclick={() =>
+                                                            startRename(child)}
+                                                        aria-label="Rename"
+                                                        title="Rename"
+                                                    >
+                                                        <Edit size={12} />
+                                                    </button>
+                                                    <button
+                                                        class="tree-action-btn tree-action-btn--delete"
+                                                        onclick={() =>
+                                                            confirmDelete(
+                                                                child,
+                                                            )}
+                                                        disabled={deletingPath ===
+                                                            child.relativePath}
+                                                        aria-label="Delete"
+                                                        title="Delete"
+                                                    >
+                                                        <TrashCan size={12} />
+                                                    </button>
+                                                </div>
+                                            </div>
                                         {/each}
                                     </div>
                                 {/if}
                             </div>
                         {:else}
-                            <button
-                                class="tree-file"
-                                class:tree-file--selected={isSelected(entry)}
-                                onclick={() => selectFile(entry)}
+                            <!-- svelte-ignore a11y_click_events_have_key_events -->
+                            <div
+                                class="tree-file-row"
+                                class:tree-file-row--selected={isSelected(
+                                    entry,
+                                )}
                             >
-                                <Document size={14} />
-                                <span>{entry.name}</span>
-                            </button>
+                                <button
+                                    class="tree-file"
+                                    onclick={() => selectFile(entry)}
+                                >
+                                    <Document size={14} />
+                                    {#if renamingPath === entry.relativePath}
+                                        <input
+                                            bind:this={renameInputEl}
+                                            type="text"
+                                            class="tree-inline-input"
+                                            bind:value={renameValue}
+                                            onkeydown={handleRenameKeydown}
+                                            onblur={confirmRename}
+                                            onclick={(e) => e.stopPropagation()}
+                                            aria-label="Rename file"
+                                        />
+                                    {:else}
+                                        <span>{entry.name}</span>
+                                    {/if}
+                                </button>
+                                <div class="tree-file-actions">
+                                    <button
+                                        class="tree-action-btn"
+                                        onclick={() => startRename(entry)}
+                                        aria-label="Rename"
+                                        title="Rename"
+                                    >
+                                        <Edit size={12} />
+                                    </button>
+                                    <button
+                                        class="tree-action-btn tree-action-btn--delete"
+                                        onclick={() => confirmDelete(entry)}
+                                        disabled={deletingPath ===
+                                            entry.relativePath}
+                                        aria-label="Delete"
+                                        title="Delete"
+                                    >
+                                        <TrashCan size={12} />
+                                    </button>
+                                </div>
+                            </div>
                         {/if}
                     {/each}
                 </nav>
@@ -465,6 +1029,10 @@
                                     <span class="board-docs-editor-saving"
                                         >Saving...</span
                                     >
+                                {:else if savedIndicator}
+                                    <span class="board-docs-editor-saved"
+                                        >Saved</span
+                                    >
                                 {/if}
                                 <button
                                     class="board-docs-done-btn"
@@ -475,20 +1043,58 @@
                                 </button>
                             </div>
                         </div>
+                        <!-- ── Formatting toolbar ────────────────────────── -->
+                        <div class="editor-toolbar">
+                            {#each FORMAT_ACTIONS as fmt}
+                                <button
+                                    class="editor-toolbar-btn"
+                                    onclick={fmt.action}
+                                    title={fmt.title}
+                                    aria-label={fmt.title}
+                                >{fmt.label}</button>
+                            {/each}
+                        </div>
                         <div class="board-docs-editor-panes">
-                            <textarea
-                                bind:this={editDraftEl}
-                                class="board-docs-editor-textarea"
-                                bind:value={draftContent}
-                                onkeydown={handleEditorKeydown}
-                                onblur={() => {
-                                    if (editing) {
-                                        void handleSave();
-                                    }
-                                }}
-                                spellcheck="false"
-                                aria-label="Markdown editor"
-                            ></textarea>
+                            <div class="editor-textarea-wrap">
+                                <!-- ── Slash command menu ────────────────── -->
+                                {#if slashOpen}
+                                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                                    <div
+                                        bind:this={slashMenuEl}
+                                        class="slash-menu"
+                                        role="listbox"
+                                        aria-label="Slash commands"
+                                    >
+                                        {#each slashFiltered as cmd, i (cmd.id)}
+                                            <button
+                                                class="slash-menu-item"
+                                                class:slash-menu-item--active={i === slashIndex}
+                                                role="option"
+                                                aria-selected={i === slashIndex}
+                                                onclick={() => applySlashCommand(cmd)}
+                                                onmouseenter={() => (slashIndex = i)}
+                                            >
+                                                <span class="slash-menu-label">{cmd.label}</span>
+                                                <span class="slash-menu-hint">/{cmd.match.split(' ')[0]}</span>
+                                            </button>
+                                        {/each}
+                                    </div>
+                                {/if}
+                                <textarea
+                                    bind:this={editDraftEl}
+                                    class="board-docs-editor-textarea"
+                                    bind:value={draftContent}
+                                    onkeydown={handleEditorKeydown}
+                                    oninput={handleFormatInput}
+                                    onblur={() => {
+                                        if (editing) {
+                                            void handleSave();
+                                        }
+                                    }}
+                                    spellcheck="false"
+                                    aria-label="Markdown editor"
+                                ></textarea>
+                            </div>
                             <div class="board-docs-editor-preview">
                                 <!-- svelte-ignore a11y_click_events_have_key_events -->
                                 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -523,6 +1129,10 @@
             </main>
         </div>
     {/if}
+    <footer class="board-docs-debug">
+        <code>docs: {docsDir(workspacePath, boardId)}</code>
+        <code>ws: {workspacePath || "(empty)"}</code>
+    </footer>
 </div>
 
 <style>
@@ -559,6 +1169,66 @@
         color: var(--cds-text-02);
         max-width: 24rem;
         line-height: 1.5;
+    }
+
+    /* ── Inline create input (empty state) ───────────────────────────────── */
+    .board-docs-inline-create {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.4375rem 0.75rem;
+        background: var(--cds-field-01, #f4f4f4);
+        border: 1px solid var(--cds-interactive-01, #0f62fe);
+        border-radius: 4px;
+        width: 100%;
+        max-width: 20rem;
+        box-sizing: border-box;
+    }
+
+    :global(.t--dark) .board-docs-inline-create {
+        background: var(--cds-field-01, #333);
+    }
+
+    .board-docs-inline-input {
+        all: unset;
+        flex: 1;
+        min-width: 0;
+        font-size: 0.875rem;
+        font-family: inherit;
+        color: var(--cds-text-01);
+        line-height: 1.4;
+    }
+
+    .board-docs-inline-input::placeholder {
+        color: var(--cds-text-03);
+    }
+
+    /* ── Error states ────────────────────────────────────────────────────── */
+    .board-docs-error-msg {
+        color: var(--cds-support-01, #da1e28) !important;
+        font-size: 0.8125rem !important;
+        background: color-mix(
+            in srgb,
+            var(--cds-support-01, #da1e28) 10%,
+            transparent
+        );
+        padding: 0.5rem 0.75rem;
+        border-radius: 4px;
+        max-width: 28rem;
+    }
+
+    .board-docs-error-bar {
+        margin: 0.25rem 0.5rem;
+        padding: 0.375rem 0.5rem;
+        font-size: 0.75rem;
+        color: var(--cds-support-01, #da1e28);
+        background: color-mix(
+            in srgb,
+            var(--cds-support-01, #da1e28) 10%,
+            transparent
+        );
+        border-radius: 3px;
+        line-height: 1.4;
     }
 
     /* ── Layout: tree sidebar + content ──────────────────────────────────── */
@@ -599,24 +1269,30 @@
         color: var(--cds-text-02);
     }
 
-    .board-docs-new-btn {
+    .board-docs-tree-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 0.125rem;
+    }
+
+    .board-docs-tree-toolbar-btn {
         all: unset;
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 24px;
-        height: 24px;
+        width: 22px;
+        height: 22px;
         border-radius: 4px;
         cursor: pointer;
         color: var(--cds-text-02);
         transition: background 0.12s ease;
     }
 
-    .board-docs-new-btn:hover {
+    .board-docs-tree-toolbar-btn:hover {
         background: var(--cds-hover-ui, #e8e8e8);
     }
 
-    .board-docs-new-btn:disabled {
+    .board-docs-tree-toolbar-btn:disabled {
         opacity: 0.4;
         cursor: default;
     }
@@ -627,32 +1303,76 @@
         padding: 0.25rem 0;
     }
 
+    /* ── Inline rename / create inputs ──────────────────────────────────── */
+    .tree-inline-input {
+        all: unset;
+        flex: 1;
+        min-width: 0;
+        font-size: inherit;
+        font-family: inherit;
+        color: inherit;
+        background: var(--cds-field-01, #f4f4f4);
+        padding: 0.0625rem 0.25rem;
+        border: 1px solid var(--cds-interactive-01, #0f62fe);
+        border-radius: 2px;
+        line-height: 1.4;
+    }
+
+    :global(.t--dark) .tree-inline-input {
+        background: var(--cds-field-01, #333);
+    }
+
+    .tree-create-input {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.3125rem 0.625rem;
+        font-size: 0.8125rem;
+        color: var(--cds-text-01);
+        line-height: 1.3;
+    }
+
     /* ── Tree nodes ──────────────────────────────────────────────────────── */
+    .tree-file-row {
+        display: flex;
+        align-items: center;
+        transition: background 0.1s ease;
+    }
+
+    .tree-file-row:hover {
+        background: var(--cds-hover-ui, #e8e8e8);
+    }
+
+    .tree-file-row--selected {
+        background: var(--cds-selected-ui, #e0e0e0);
+    }
+
+    .tree-file-row--selected .tree-file span {
+        font-weight: 500;
+    }
+
     .tree-file,
     .tree-folder-toggle {
         all: unset;
         display: flex;
         align-items: center;
         gap: 0.375rem;
-        width: 100%;
+        flex: 1;
+        min-width: 0;
         padding: 0.3125rem 0.625rem;
         font-size: 0.8125rem;
         color: var(--cds-text-01);
         cursor: pointer;
         box-sizing: border-box;
-        transition: background 0.1s ease;
         line-height: 1.3;
     }
 
-    .tree-file:hover,
-    .tree-folder-toggle:hover {
-        background: var(--cds-hover-ui, #e8e8e8);
+    .tree-file:hover {
+        background: transparent;
     }
 
-    .tree-file--selected {
-        background: var(--cds-selected-ui, #e0e0e0);
-        color: var(--cds-text-01);
-        font-weight: 500;
+    .tree-folder-toggle:hover {
+        background: var(--cds-hover-ui, #e8e8e8);
     }
 
     .tree-folder-toggle {
@@ -668,6 +1388,49 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+    }
+
+    /* ── Tree item action buttons (rename, delete) ───────────────────────── */
+    .tree-file-actions {
+        display: none;
+        align-items: center;
+        gap: 0.125rem;
+        padding-right: 0.25rem;
+        flex-shrink: 0;
+    }
+
+    .tree-file-row:hover .tree-file-actions {
+        display: flex;
+    }
+
+    .tree-action-btn {
+        all: unset;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        height: 20px;
+        border-radius: 3px;
+        cursor: pointer;
+        color: var(--cds-text-03);
+        transition:
+            color 0.1s ease,
+            background 0.1s ease;
+        flex-shrink: 0;
+    }
+
+    .tree-action-btn:hover {
+        background: var(--cds-hover-ui, #d8d8d8);
+        color: var(--cds-text-01);
+    }
+
+    .tree-action-btn--delete:hover {
+        color: var(--cds-support-01, #da1e28);
+    }
+
+    .tree-action-btn:disabled {
+        opacity: 0.3;
+        cursor: default;
     }
 
     /* ── Content Area ────────────────────────────────────────────────────── */
@@ -744,16 +1507,75 @@
         background: var(--cds-hover-ui, #e8e8e8);
     }
 
-    /* ── Editor split pane ───────────────────────────────────────────────── */
+    /* ── Editor ──────────────────────────────────────────────────────────── */
+    .board-docs-editor {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
     .board-docs-editor-panes {
         flex: 1;
         display: flex;
+        flex-direction: row;
+        min-height: 0;
+    }
+
+    /* ── Formatting toolbar ──────────────────────────────────────────────── */
+    .editor-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 0.125rem;
+        padding: 0.25rem 0.5rem;
+        border-bottom: 1px solid var(--cds-ui-03);
+        background: var(--cds-ui-01, #f4f4f4);
+        flex-shrink: 0;
+        flex-wrap: wrap;
+    }
+
+    :global(.t--dark) .editor-toolbar {
+        background: var(--cds-ui-01, #2c2c2c);
+    }
+
+    .editor-toolbar-btn {
+        all: unset;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 28px;
+        height: 26px;
+        padding: 0 0.25rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--cds-text-02);
+        cursor: pointer;
+        border-radius: 3px;
+        transition: background 0.1s ease, color 0.1s ease;
+        font-family: 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace;
+    }
+
+    .editor-toolbar-btn:hover {
+        background: var(--cds-hover-ui, #e8e8e8);
+        color: var(--cds-text-01);
+    }
+
+    .editor-toolbar-btn:active {
+        background: var(--cds-selected-ui, #d8d8d8);
+    }
+
+    /* ── Textarea wrapper (for slash menu positioning) ───────────────────── */
+    .editor-textarea-wrap {
+        flex: 1;
+        display: flex;
+        position: relative;
         min-height: 0;
     }
 
     .board-docs-editor-textarea {
         flex: 1;
         min-width: 0;
+        min-height: 0;
         resize: none;
         border: none;
         outline: none;
@@ -775,6 +1597,58 @@
         color: var(--cds-text-03);
     }
 
+    /* ── Slash command menu ──────────────────────────────────────────────── */
+    .slash-menu {
+        position: absolute;
+        top: 0.25rem;
+        left: 0.5rem;
+        z-index: 100;
+        min-width: 180px;
+        max-height: 240px;
+        overflow-y: auto;
+        background: var(--cds-ui-01, #f4f4f4);
+        border: 1px solid var(--cds-ui-03);
+        border-radius: 6px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        padding: 0.25rem;
+    }
+
+    :global(.t--dark) .slash-menu {
+        background: var(--cds-ui-01, #2c2c2c);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+
+    .slash-menu-item {
+        all: unset;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        padding: 0.375rem 0.625rem;
+        font-size: 0.8125rem;
+        color: var(--cds-text-01);
+        cursor: pointer;
+        border-radius: 4px;
+        box-sizing: border-box;
+        transition: background 0.08s ease;
+    }
+
+    .slash-menu-item:hover,
+    .slash-menu-item--active {
+        background: var(--cds-hover-ui, #e8e8e8);
+    }
+
+    .slash-menu-label {
+        font-weight: 500;
+    }
+
+    .slash-menu-hint {
+        font-size: 0.6875rem;
+        color: var(--cds-text-03);
+        font-family: 'IBM Plex Mono', 'SF Mono', monospace;
+        margin-left: 1rem;
+    }
+
     .board-docs-editor-preview {
         flex: 1;
         min-width: 0;
@@ -792,6 +1666,19 @@
         font-size: 0.75rem;
         color: var(--cds-text-03);
         animation: docs-saving-pulse 1s ease-in-out infinite;
+    }
+
+    .board-docs-editor-saved {
+        font-size: 0.75rem;
+        color: var(--cds-support-02, #24a148);
+        font-weight: 500;
+        animation: docs-saved-fade 1.5s ease-out forwards;
+    }
+
+    @keyframes docs-saved-fade {
+        0% { opacity: 1; }
+        70% { opacity: 1; }
+        100% { opacity: 0; }
     }
 
     @keyframes docs-saving-pulse {
@@ -896,5 +1783,28 @@
 
     .markdown-body :global(strong) {
         font-weight: 600;
+    }
+
+    /* ── Debug footer ────────────────────────────────────────────────────── */
+    .board-docs-debug {
+        flex-shrink: 0;
+        display: flex;
+        gap: 1rem;
+        padding: 0.25rem 0.625rem;
+        font-size: 0.6875rem;
+        color: var(--cds-text-03);
+        background: var(--cds-ui-02, #f4f4f4);
+        border-top: 1px solid var(--cds-ui-03);
+        overflow: hidden;
+    }
+
+    :global(.t--dark) .board-docs-debug {
+        background: var(--cds-ui-02, #393939);
+    }
+
+    .board-docs-debug code {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 </style>

--- a/packages/worklog/src/lib/components/app/board/board-docs.svelte
+++ b/packages/worklog/src/lib/components/app/board/board-docs.svelte
@@ -1,0 +1,900 @@
+<script lang="ts">
+    import {
+        Document,
+        DocumentAdd,
+        Edit,
+        Folder,
+        ChevronRight,
+        ChevronDown,
+        Notebook,
+    } from "carbon-icons-svelte";
+    import { Button } from "carbon-components-svelte";
+    import {
+        listDocFiles,
+        readDocFile,
+        writeDocFile,
+        createDocFile,
+        docsDirectoryExists,
+        type DocFileEntry,
+    } from "$lib/hooks/board-docs.svelte";
+
+    interface Props {
+        workspacePath: string;
+        boardId: string;
+    }
+
+    let { workspacePath, boardId }: Props = $props();
+
+    // ── State ──────────────────────────────────────────────────────────────
+    let files = $state<DocFileEntry[]>([]);
+    let selectedPath = $state<string | null>(null);
+    let fileContent = $state<string | null>(null);
+    let loading = $state(true);
+    let hasDocsDir = $state(false);
+    let expandedFolders = $state<Set<string>>(new Set());
+    let error = $state<string | null>(null);
+
+    // ── Editor state ───────────────────────────────────────────────────────
+    let editing = $state(false);
+    let draftContent = $state("");
+    let pendingSave = $state(false);
+    let editDraftEl = $state<HTMLTextAreaElement | null>(null);
+    let saving = $state(false);
+
+    // ── Load file tree ─────────────────────────────────────────────────────
+    async function loadFiles() {
+        loading = true;
+        error = null;
+        try {
+            const exists = await docsDirectoryExists(workspacePath, boardId);
+            hasDocsDir = exists;
+
+            if (exists) {
+                const entries = await listDocFiles(workspacePath, boardId);
+                files = entries;
+                // Auto-expand all top-level directories
+                for (const entry of entries) {
+                    if (entry.isDir) {
+                        expandedFolders.add(entry.relativePath);
+                    }
+                }
+            }
+        } catch (e) {
+            error = String(e);
+            files = [];
+        } finally {
+            loading = false;
+        }
+    }
+
+    // Reload when board changes
+    $effect(() => {
+        // Read reactive deps
+        const _workspacePath = workspacePath;
+        const _boardId = boardId;
+        if (!_workspacePath || !_boardId) return;
+        void loadFiles();
+    });
+
+    // ── File selection ─────────────────────────────────────────────────────
+    let prevSelectedPath = $state<string | null>(null);
+
+    async function selectFile(entry: DocFileEntry) {
+        if (entry.isDir) return;
+        selectedPath = entry.relativePath;
+    }
+
+    $effect(() => {
+        if (!selectedPath || selectedPath === prevSelectedPath) return;
+        prevSelectedPath = selectedPath;
+        fileContent = null;
+
+        void (async () => {
+            try {
+                const content = await readDocFile(
+                    workspacePath,
+                    boardId,
+                    selectedPath!,
+                );
+                fileContent = content;
+            } catch (e) {
+                fileContent = `*Error reading file: ${e}*`;
+            }
+        })();
+    });
+
+    // ── Create new note ────────────────────────────────────────────────────
+    let creating = $state(false);
+
+    async function handleCreateNote() {
+        creating = true;
+        try {
+            const result = await createDocFile(
+                workspacePath,
+                boardId,
+                "README.md",
+                `# ${boardId}\n\nNotes for this board.\n`,
+            );
+            if (result) {
+                await loadFiles();
+                // Auto-select the new file
+                const newEntry = findEntry(files, result);
+                if (newEntry) {
+                    selectedPath = newEntry.relativePath;
+                }
+            }
+        } finally {
+            creating = false;
+        }
+    }
+
+    function findEntry(
+        entries: DocFileEntry[],
+        relativePath: string,
+    ): DocFileEntry | null {
+        for (const entry of entries) {
+            if (entry.relativePath === relativePath) return entry;
+            if (entry.isDir) {
+                const found = findEntry(entry.children, relativePath);
+                if (found) return found;
+            }
+        }
+        return null;
+    }
+
+    // ── Editor mode ────────────────────────────────────────────────────────
+    function enterEditMode() {
+        if (!fileContent) return;
+        draftContent = fileContent;
+        editing = true;
+
+        // Focus textarea on next tick after render
+        requestAnimationFrame(() => {
+            editDraftEl?.focus();
+        });
+    }
+
+    async function handleSave() {
+        if (!selectedPath || saving) return;
+        saving = true;
+        try {
+            const saved = await writeDocFile(
+                workspacePath,
+                boardId,
+                selectedPath,
+                draftContent,
+            );
+            if (saved) {
+                fileContent = draftContent;
+            }
+        } finally {
+            saving = false;
+        }
+    }
+
+    function exitEditMode() {
+        void handleSave().then(() => {
+            editing = false;
+        });
+    }
+
+    function handleEditorKeydown(e: KeyboardEvent) {
+        // Ctrl+S → save
+        if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+            e.preventDefault();
+            void handleSave();
+            return;
+        }
+        // Esc → save & exit
+        if (e.key === "Escape") {
+            e.preventDefault();
+            void exitEditMode();
+            return;
+        }
+    }
+
+    // When switching files while editing, save first
+    $effect(() => {
+        if (!editing || !selectedPath) return;
+        if (selectedPath !== prevSelectedPath) {
+            // User clicked a different file — save draft first
+            void handleSave().then(() => {
+                editing = false;
+            });
+        }
+    });
+
+    // ── Folder toggle ──────────────────────────────────────────────────────
+    function toggleFolder(relativePath: string) {
+        if (expandedFolders.has(relativePath)) {
+            expandedFolders.delete(relativePath);
+        } else {
+            expandedFolders.add(relativePath);
+        }
+        // Trigger reactivity by creating a new Set
+        expandedFolders = new Set(expandedFolders);
+    }
+
+    // ── Inline markdown renderer ───────────────────────────────────────────
+    function renderMarkdown(md: string): string {
+        const lines = md.split("\n");
+        const htmlParts: string[] = [];
+        let inParagraph = false;
+
+        function closeParagraph() {
+            if (inParagraph) {
+                htmlParts.push("</p>");
+                inParagraph = false;
+            }
+        }
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            const trimmed = line.trim();
+
+            // Blank line → paragraph break
+            if (trimmed === "") {
+                closeParagraph();
+                continue;
+            }
+
+            // Headings
+            const headingMatch = trimmed.match(/^(#{1,6})\s+(.+)$/);
+            if (headingMatch) {
+                closeParagraph();
+                const level = headingMatch[1].length;
+                const text = escapeHtml(inlineMarkdown(headingMatch[2]));
+                htmlParts.push(`<h${level}>${text}</h${level}>`);
+                continue;
+            }
+
+            // Unordered list items
+            const listMatch = trimmed.match(/^[-*+]\s+(.+)$/);
+            if (listMatch) {
+                closeParagraph();
+                const text = escapeHtml(inlineMarkdown(listMatch[1]));
+                htmlParts.push(`<li>${text}</li>`);
+                continue;
+            }
+
+            // Horizontal rule
+            if (/^(-{3,}|\*{3,})$/.test(trimmed)) {
+                closeParagraph();
+                htmlParts.push("<hr>");
+                continue;
+            }
+
+            // Regular paragraph line
+            if (!inParagraph) {
+                htmlParts.push("<p>");
+                inParagraph = true;
+            } else {
+                htmlParts.push("<br>");
+            }
+            htmlParts.push(escapeHtml(inlineMarkdown(trimmed)));
+        }
+
+        closeParagraph();
+        return htmlParts.join("\n");
+    }
+
+    /** Process inline markdown within a line of text (bold, code, links). */
+    function inlineMarkdown(text: string): string {
+        // Bold: **text** or __text__
+        text = text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+        text = text.replace(/__(.+?)__/g, "<strong>$1</strong>");
+        // Italic: *text* or _text_
+        text = text.replace(/\*(.+?)\*/g, "<em>$1</em>");
+        text = text.replace(/_(.+?)_/g, "<em>$1</em>");
+        // Inline code: `code`
+        text = text.replace(/`(.+?)`/g, "<code>$1</code>");
+        // Links: [text](url)
+        text = text.replace(
+            /\[(.+?)\]\((.+?)\)/g,
+            '<a href="$2" target="_blank" rel="noopener">$1</a>',
+        );
+        return text;
+    }
+
+    function escapeHtml(text: string): string {
+        return text
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;");
+    }
+
+    // ── File tree rendering helpers ────────────────────────────────────────
+    function isSelected(entry: DocFileEntry): boolean {
+        return entry.relativePath === selectedPath;
+    }
+
+    function isExpanded(entry: DocFileEntry): boolean {
+        return expandedFolders.has(entry.relativePath);
+    }
+
+    function fileIcon(_entry: DocFileEntry): any {
+        return Document;
+    }
+</script>
+
+<div class="board-docs">
+    {#if loading}
+        <div class="board-docs-loading">
+            <span>Loading docs...</span>
+        </div>
+    {:else if !hasDocsDir && files.length === 0}
+        <div class="board-docs-empty">
+            <Notebook size={48} />
+            <h2>No docs yet</h2>
+            <p>Create your first markdown note for this board.</p>
+            <Button
+                kind="primary"
+                icon={DocumentAdd}
+                onclick={handleCreateNote}
+                disabled={creating}
+            >
+                {creating ? "Creating..." : "New Note"}
+            </Button>
+        </div>
+    {:else}
+        <div class="board-docs-layout">
+            <!-- ── File Tree Sidebar ─────────────────────────────────────── -->
+            <aside class="board-docs-tree">
+                <div class="board-docs-tree-header">
+                    <span class="board-docs-tree-title">Docs</span>
+                    <button
+                        class="board-docs-new-btn"
+                        onclick={handleCreateNote}
+                        disabled={creating}
+                        aria-label="Create new note"
+                        title="New note"
+                    >
+                        <DocumentAdd size={16} />
+                    </button>
+                </div>
+                <nav class="board-docs-tree-list" aria-label="Document files">
+                    {#each files as entry (entry.relativePath)}
+                        {#if entry.isDir}
+                            <div class="tree-folder">
+                                <button
+                                    class="tree-folder-toggle"
+                                    onclick={() =>
+                                        toggleFolder(entry.relativePath)}
+                                    aria-expanded={isExpanded(entry)}
+                                >
+                                    {#if isExpanded(entry)}
+                                        <ChevronDown size={14} />
+                                    {:else}
+                                        <ChevronRight size={14} />
+                                    {/if}
+                                    <Folder size={14} />
+                                    <span>{entry.name}</span>
+                                </button>
+                                {#if isExpanded(entry)}
+                                    <div class="tree-folder-children">
+                                        {#each entry.children as child (child.relativePath)}
+                                            <button
+                                                class="tree-file"
+                                                class:tree-file--selected={isSelected(
+                                                    child,
+                                                )}
+                                                onclick={() =>
+                                                    selectFile(child)}
+                                            >
+                                                <Document size={14} />
+                                                <span>{child.name}</span>
+                                            </button>
+                                        {/each}
+                                    </div>
+                                {/if}
+                            </div>
+                        {:else}
+                            <button
+                                class="tree-file"
+                                class:tree-file--selected={isSelected(entry)}
+                                onclick={() => selectFile(entry)}
+                            >
+                                <Document size={14} />
+                                <span>{entry.name}</span>
+                            </button>
+                        {/if}
+                    {/each}
+                </nav>
+            </aside>
+
+            <!-- ── Content Area ──────────────────────────────────────────── -->
+            <main class="board-docs-content">
+                {#if !selectedPath}
+                    <div class="board-docs-content-empty">
+                        <Notebook size={40} />
+                        <p>Select a file from the tree to preview it</p>
+                    </div>
+                {:else if fileContent === null}
+                    <div class="board-docs-content-loading">
+                        <span>Loading...</span>
+                    </div>
+                {:else if !editing}
+                    <!-- ── Read-Only Preview ────────────────────────────── -->
+                    <article class="board-docs-preview">
+                        <div class="board-docs-preview-header">
+                            <span class="board-docs-preview-filename"
+                                >{selectedPath}</span
+                            >
+                            <button
+                                class="board-docs-edit-btn"
+                                onclick={enterEditMode}
+                                aria-label="Edit file"
+                                title="Edit (E)"
+                            >
+                                <Edit size={14} />
+                                <span>Edit</span>
+                            </button>
+                        </div>
+                        <!-- svelte-ignore a11y_click_events_have_key_events -->
+                        <!-- svelte-ignore a11y_no_static_element_interactions -->
+                        <div
+                            class="markdown-body"
+                            onclick={(e) => {
+                                // Open external links in new window
+                                const target = e.target as HTMLElement;
+                                if (
+                                    target.tagName === "A" &&
+                                    target.getAttribute("target") === "_blank"
+                                ) {
+                                    e.preventDefault();
+                                    const href = target.getAttribute("href");
+                                    if (href) {
+                                        window.open(href, "_blank", "noopener");
+                                    }
+                                }
+                            }}
+                        >
+                            {@html renderMarkdown(fileContent)}
+                        </div>
+                    </article>
+                {:else}
+                    <!-- ── Split-Pane Editor ────────────────────────────── -->
+                    <article class="board-docs-editor">
+                        <div class="board-docs-editor-header">
+                            <span class="board-docs-editor-filename"
+                                >{selectedPath}</span
+                            >
+                            <div class="board-docs-editor-actions">
+                                {#if saving}
+                                    <span class="board-docs-editor-saving"
+                                        >Saving...</span
+                                    >
+                                {/if}
+                                <button
+                                    class="board-docs-done-btn"
+                                    onclick={exitEditMode}
+                                    disabled={saving}
+                                >
+                                    Done
+                                </button>
+                            </div>
+                        </div>
+                        <div class="board-docs-editor-panes">
+                            <textarea
+                                bind:this={editDraftEl}
+                                class="board-docs-editor-textarea"
+                                bind:value={draftContent}
+                                onkeydown={handleEditorKeydown}
+                                onblur={() => {
+                                    if (editing) {
+                                        void handleSave();
+                                    }
+                                }}
+                                spellcheck="false"
+                                aria-label="Markdown editor"
+                            ></textarea>
+                            <div class="board-docs-editor-preview">
+                                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                                <div
+                                    class="markdown-body"
+                                    onclick={(e) => {
+                                        const target = e.target as HTMLElement;
+                                        if (
+                                            target.tagName === "A" &&
+                                            target.getAttribute("target") ===
+                                                "_blank"
+                                        ) {
+                                            e.preventDefault();
+                                            const href =
+                                                target.getAttribute("href");
+                                            if (href) {
+                                                window.open(
+                                                    href,
+                                                    "_blank",
+                                                    "noopener",
+                                                );
+                                            }
+                                        }
+                                    }}
+                                >
+                                    {@html renderMarkdown(draftContent)}
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                {/if}
+            </main>
+        </div>
+    {/if}
+</div>
+
+<style>
+    .board-docs {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
+    /* ── Loading / Empty states ──────────────────────────────────────────── */
+    .board-docs-loading,
+    .board-docs-empty {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: var(--cds-spacing-04, 0.75rem);
+        color: var(--cds-text-02);
+        text-align: center;
+        padding: var(--cds-spacing-07, 2rem);
+    }
+
+    .board-docs-empty h2 {
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--cds-text-01);
+    }
+
+    .board-docs-empty p {
+        margin: 0;
+        font-size: 0.875rem;
+        color: var(--cds-text-02);
+        max-width: 24rem;
+        line-height: 1.5;
+    }
+
+    /* ── Layout: tree sidebar + content ──────────────────────────────────── */
+    .board-docs-layout {
+        display: flex;
+        flex: 1;
+        min-height: 0;
+    }
+
+    /* ── File Tree Sidebar ───────────────────────────────────────────────── */
+    .board-docs-tree {
+        width: 220px;
+        flex-shrink: 0;
+        border-right: 1px solid var(--cds-ui-03);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        background: var(--cds-ui-01, #f4f4f4);
+    }
+
+    :global(.t--dark) .board-docs-tree {
+        background: var(--cds-ui-01, #2c2c2c);
+    }
+
+    .board-docs-tree-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.625rem;
+        border-bottom: 1px solid var(--cds-ui-03);
+    }
+
+    .board-docs-tree-title {
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--cds-text-02);
+    }
+
+    .board-docs-new-btn {
+        all: unset;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        border-radius: 4px;
+        cursor: pointer;
+        color: var(--cds-text-02);
+        transition: background 0.12s ease;
+    }
+
+    .board-docs-new-btn:hover {
+        background: var(--cds-hover-ui, #e8e8e8);
+    }
+
+    .board-docs-new-btn:disabled {
+        opacity: 0.4;
+        cursor: default;
+    }
+
+    .board-docs-tree-list {
+        flex: 1;
+        overflow-y: auto;
+        padding: 0.25rem 0;
+    }
+
+    /* ── Tree nodes ──────────────────────────────────────────────────────── */
+    .tree-file,
+    .tree-folder-toggle {
+        all: unset;
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        width: 100%;
+        padding: 0.3125rem 0.625rem;
+        font-size: 0.8125rem;
+        color: var(--cds-text-01);
+        cursor: pointer;
+        box-sizing: border-box;
+        transition: background 0.1s ease;
+        line-height: 1.3;
+    }
+
+    .tree-file:hover,
+    .tree-folder-toggle:hover {
+        background: var(--cds-hover-ui, #e8e8e8);
+    }
+
+    .tree-file--selected {
+        background: var(--cds-selected-ui, #e0e0e0);
+        color: var(--cds-text-01);
+        font-weight: 500;
+    }
+
+    .tree-folder-toggle {
+        font-weight: 500;
+    }
+
+    .tree-folder-children {
+        padding-left: 1.25rem;
+    }
+
+    .tree-file span,
+    .tree-folder-toggle span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    /* ── Content Area ────────────────────────────────────────────────────── */
+    .board-docs-content {
+        flex: 1;
+        min-width: 0;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .board-docs-content-empty,
+    .board-docs-content-loading {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: var(--cds-spacing-03, 0.5rem);
+        color: var(--cds-text-02);
+        font-size: 0.875rem;
+        padding: var(--cds-spacing-07, 2rem);
+    }
+
+    .board-docs-preview,
+    .board-docs-editor {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    .board-docs-preview {
+        padding: 0;
+        max-width: 48rem;
+    }
+
+    /* ── Preview header ──────────────────────────────────────────────────── */
+    .board-docs-preview-header,
+    .board-docs-editor-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.4375rem 1.25rem;
+        border-bottom: 1px solid var(--cds-ui-03);
+        flex-shrink: 0;
+    }
+
+    .board-docs-preview-filename,
+    .board-docs-editor-filename {
+        font-size: 0.8125rem;
+        font-weight: 500;
+        color: var(--cds-text-02);
+        font-family: "IBM Plex Mono", "SF Mono", "Fira Code", monospace;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .board-docs-edit-btn {
+        all: unset;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3125rem;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.8125rem;
+        color: var(--cds-text-02);
+        cursor: pointer;
+        border-radius: 4px;
+        transition: background 0.12s ease;
+    }
+
+    .board-docs-edit-btn:hover {
+        background: var(--cds-hover-ui, #e8e8e8);
+    }
+
+    /* ── Editor split pane ───────────────────────────────────────────────── */
+    .board-docs-editor-panes {
+        flex: 1;
+        display: flex;
+        min-height: 0;
+    }
+
+    .board-docs-editor-textarea {
+        flex: 1;
+        min-width: 0;
+        resize: none;
+        border: none;
+        outline: none;
+        padding: 1rem;
+        font-family: "IBM Plex Mono", "SF Mono", "Fira Code", monospace;
+        font-size: 0.875rem;
+        line-height: 1.6;
+        color: var(--cds-text-01);
+        background: var(--cds-ui-background, #ffffff);
+        border-right: 1px solid var(--cds-ui-03);
+        tab-size: 2;
+    }
+
+    :global(.t--dark) .board-docs-editor-textarea {
+        background: var(--cds-ui-background, #1a1a1a);
+    }
+
+    .board-docs-editor-textarea::placeholder {
+        color: var(--cds-text-03);
+    }
+
+    .board-docs-editor-preview {
+        flex: 1;
+        min-width: 0;
+        overflow-y: auto;
+        padding: 1rem 1.25rem;
+    }
+
+    .board-docs-editor-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .board-docs-editor-saving {
+        font-size: 0.75rem;
+        color: var(--cds-text-03);
+        animation: docs-saving-pulse 1s ease-in-out infinite;
+    }
+
+    @keyframes docs-saving-pulse {
+        0%,
+        100% {
+            opacity: 0.5;
+        }
+        50% {
+            opacity: 1;
+        }
+    }
+
+    .board-docs-done-btn {
+        all: unset;
+        display: inline-flex;
+        align-items: center;
+        padding: 0.25rem 0.75rem;
+        font-size: 0.8125rem;
+        font-weight: 500;
+        color: var(--cds-text-04, #ffffff);
+        background: var(--cds-interactive-01, #0f62fe);
+        border-radius: 4px;
+        cursor: pointer;
+        transition: background 0.12s ease;
+    }
+
+    .board-docs-done-btn:hover {
+        background: var(--cds-hover-primary, #0353e9);
+    }
+
+    .board-docs-done-btn:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+
+    .board-docs-preview .markdown-body {
+        padding: 1.25rem 1.5rem;
+    }
+
+    /* ── Markdown rendered body ──────────────────────────────────────────── */
+    .markdown-body {
+        font-size: 0.9375rem;
+        line-height: 1.65;
+        color: var(--cds-text-01);
+        word-wrap: break-word;
+    }
+
+    .markdown-body :global(h1) {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin: 0 0 0.75rem 0;
+        padding-bottom: 0.375rem;
+        border-bottom: 1px solid var(--cds-ui-03);
+    }
+
+    .markdown-body :global(h2) {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin: 1.25rem 0 0.5rem 0;
+    }
+
+    .markdown-body :global(h3) {
+        font-size: 1.0625rem;
+        font-weight: 600;
+        margin: 1rem 0 0.375rem 0;
+    }
+
+    .markdown-body :global(p) {
+        margin: 0 0 0.625rem 0;
+    }
+
+    .markdown-body :global(li) {
+        margin: 0.1875rem 0;
+        padding-left: 0.375rem;
+        list-style: disc;
+        margin-left: 1.25rem;
+        font-size: 0.9375rem;
+    }
+
+    .markdown-body :global(code) {
+        font-family: "IBM Plex Mono", "SF Mono", "Fira Code", monospace;
+        font-size: 0.8125rem;
+        background: var(--cds-ui-02, #f4f4f4);
+        padding: 0.125rem 0.375rem;
+        border-radius: 3px;
+    }
+
+    :global(.t--dark) .markdown-body :global(code) {
+        background: var(--cds-ui-02, #393939);
+    }
+
+    .markdown-body :global(a) {
+        color: var(--cds-link-01, #0f62fe);
+        text-decoration: underline;
+    }
+
+    .markdown-body :global(hr) {
+        border: none;
+        border-top: 1px solid var(--cds-ui-03);
+        margin: 1rem 0;
+    }
+
+    .markdown-body :global(strong) {
+        font-weight: 600;
+    }
+</style>

--- a/packages/worklog/src/lib/hooks/board-docs.svelte.ts
+++ b/packages/worklog/src/lib/hooks/board-docs.svelte.ts
@@ -2,9 +2,9 @@
  * Hook for browsing and reading board documentation markdown files.
  *
  * Files live on the filesystem at `.worklog/boards/<board_id>/docs/`.
- * All Tauri plugin calls are lazy-loaded with try/catch for safety
- * in browser dev mode.
  */
+
+import { exists, mkdir, readDir, readTextFile, remove, rename, writeTextFile } from '@tauri-apps/plugin-fs';
 
 export interface DocFileEntry {
     /** Display name (e.g. "README.md", "meeting-notes/2026-06-17.md") */
@@ -19,7 +19,7 @@ export interface DocFileEntry {
     children: DocFileEntry[];
 }
 
-function docsDir(workspacePath: string, boardId: string): string {
+export function docsDir(workspacePath: string, boardId: string): string {
     return `${workspacePath}/.worklog/boards/${boardId}/docs`;
 }
 
@@ -32,14 +32,13 @@ export async function listDocFiles(
     boardId: string,
 ): Promise<DocFileEntry[]> {
     try {
-        const { exists, readDir } = await import('@tauri-apps/plugin-fs');
         const dir = docsDir(workspacePath, boardId);
         const dirExists = await exists(dir);
         if (!dirExists) return [];
 
         return await listDirRecursive(dir, dir);
     } catch (e) {
-        console.warn('[board-docs] Failed to list doc files:', e);
+        console.error('[board-docs] Failed to list doc files:', e);
         return [];
     }
 }
@@ -48,7 +47,6 @@ async function listDirRecursive(
     absoluteDir: string,
     rootDir: string,
 ): Promise<DocFileEntry[]> {
-    const { readDir } = await import('@tauri-apps/plugin-fs');
     const entries = await readDir(absoluteDir);
     const results: DocFileEntry[] = [];
 
@@ -107,11 +105,10 @@ export async function readDocFile(
     relativePath: string,
 ): Promise<string | null> {
     try {
-        const { readTextFile } = await import('@tauri-apps/plugin-fs');
         const fullPath = `${docsDir(workspacePath, boardId)}/${relativePath}`;
         return await readTextFile(fullPath);
     } catch (e) {
-        console.warn(`[board-docs] Failed to read file ${relativePath}:`, e);
+        console.error(`[board-docs] Failed to read file ${relativePath}:`, e);
         return null;
     }
 }
@@ -128,7 +125,6 @@ export async function createDocFile(
     content = '',
 ): Promise<string | null> {
     try {
-        const { mkdir, exists, writeTextFile } = await import('@tauri-apps/plugin-fs');
         const dir = docsDir(workspacePath, boardId);
 
         // Ensure docs directory exists
@@ -149,9 +145,10 @@ export async function createDocFile(
         }
 
         await writeTextFile(fullPath, content);
+        console.log(`[board-docs] Created: ${fullPath}`);
         return fileName;
     } catch (e) {
-        console.warn(`[board-docs] Failed to create file ${fileName}:`, e);
+        console.error(`[board-docs] Failed to create file ${fileName}:`, e);
         return null;
     }
 }
@@ -168,7 +165,6 @@ export async function writeDocFile(
     content: string,
 ): Promise<boolean> {
     try {
-        const { mkdir, exists, writeTextFile } = await import('@tauri-apps/plugin-fs');
         const fullPath = `${docsDir(workspacePath, boardId)}/${relativePath}`;
 
         // Ensure parent directory exists
@@ -181,8 +177,75 @@ export async function writeDocFile(
         await writeTextFile(fullPath, content);
         return true;
     } catch (e) {
-        console.warn(`[board-docs] Failed to write file ${relativePath}:`, e);
+        console.error(`[board-docs] Failed to write file ${relativePath}:`, e);
         return false;
+    }
+}
+
+/**
+ * Delete a markdown file from the board's docs directory.
+ * Returns true on success, false on failure.
+ */
+export async function deleteDocFile(
+    workspacePath: string,
+    boardId: string,
+    relativePath: string,
+): Promise<boolean> {
+    try {
+        const fullPath = `${docsDir(workspacePath, boardId)}/${relativePath}`;
+        await remove(fullPath);
+        return true;
+    } catch (e) {
+                console.error(`[board-docs] Failed to delete file ${relativePath}:`, e);
+        return false;
+    }
+}
+
+/**
+ * Rename a file or directory inside the board's docs directory.
+ * Returns the new relative path on success, null on failure.
+ */
+export async function renameDocFile(
+    workspacePath: string,
+    boardId: string,
+    oldRelativePath: string,
+    newName: string,
+): Promise<string | null> {
+    try {
+        const dir = docsDir(workspacePath, boardId);
+        const oldFullPath = `${dir}/${oldRelativePath}`;
+
+        // Compute new relative path by replacing the last segment
+        const parts = oldRelativePath.split('/');
+        parts[parts.length - 1] = newName;
+        const newRelativePath = parts.join('/');
+        const newFullPath = `${dir}/${newRelativePath}`;
+
+        await rename(oldFullPath, newFullPath);
+        return newRelativePath;
+    } catch (e) {
+                console.error(`[board-docs] Failed to rename ${oldRelativePath}:`, e);
+        return null;
+    }
+}
+
+/**
+ * Create a new subdirectory inside the board's docs directory.
+ * Returns the relative path on success, null on failure.
+ */
+export async function createDocFolder(
+    workspacePath: string,
+    boardId: string,
+    folderName: string,
+): Promise<string | null> {
+    try {
+        const dir = docsDir(workspacePath, boardId);
+        const fullPath = `${dir}/${folderName}`;
+        await mkdir(fullPath, { recursive: true });
+        return folderName;
+    } catch (e) {
+                console.error(`[board-docs] Failed to create folder ${folderName}:`, e);
+        return null;
     }
 }
 
@@ -194,7 +257,6 @@ export async function docsDirectoryExists(
     boardId: string,
 ): Promise<boolean> {
     try {
-        const { exists } = await import('@tauri-apps/plugin-fs');
         return await exists(docsDir(workspacePath, boardId));
     } catch {
         return false;

--- a/packages/worklog/src/lib/hooks/board-docs.svelte.ts
+++ b/packages/worklog/src/lib/hooks/board-docs.svelte.ts
@@ -196,7 +196,7 @@ export async function deleteDocFile(
         await remove(fullPath);
         return true;
     } catch (e) {
-                console.error(`[board-docs] Failed to delete file ${relativePath}:`, e);
+        console.error(`[board-docs] Failed to delete file ${relativePath}:`, e);
         return false;
     }
 }
@@ -224,7 +224,7 @@ export async function renameDocFile(
         await rename(oldFullPath, newFullPath);
         return newRelativePath;
     } catch (e) {
-                console.error(`[board-docs] Failed to rename ${oldRelativePath}:`, e);
+        console.error(`[board-docs] Failed to rename ${oldRelativePath}:`, e);
         return null;
     }
 }
@@ -244,7 +244,7 @@ export async function createDocFolder(
         await mkdir(fullPath, { recursive: true });
         return folderName;
     } catch (e) {
-                console.error(`[board-docs] Failed to create folder ${folderName}:`, e);
+        console.error(`[board-docs] Failed to create folder ${folderName}:`, e);
         return null;
     }
 }

--- a/packages/worklog/src/lib/hooks/board-docs.svelte.ts
+++ b/packages/worklog/src/lib/hooks/board-docs.svelte.ts
@@ -1,0 +1,202 @@
+/**
+ * Hook for browsing and reading board documentation markdown files.
+ *
+ * Files live on the filesystem at `.worklog/boards/<board_id>/docs/`.
+ * All Tauri plugin calls are lazy-loaded with try/catch for safety
+ * in browser dev mode.
+ */
+
+export interface DocFileEntry {
+    /** Display name (e.g. "README.md", "meeting-notes/2026-06-17.md") */
+    name: string;
+    /** Relative path from the docs root (e.g. "README.md", "meeting-notes/2026-06-17.md") */
+    relativePath: string;
+    /** Full absolute path on disk */
+    fullPath: string;
+    /** Whether this entry is a directory */
+    isDir: boolean;
+    /** Child entries (populated for directories) */
+    children: DocFileEntry[];
+}
+
+function docsDir(workspacePath: string, boardId: string): string {
+    return `${workspacePath}/.worklog/boards/${boardId}/docs`;
+}
+
+/**
+ * Recursively list all `.md` files in a board's docs directory.
+ * Returns empty array if the directory doesn't exist yet.
+ */
+export async function listDocFiles(
+    workspacePath: string,
+    boardId: string,
+): Promise<DocFileEntry[]> {
+    try {
+        const { exists, readDir } = await import('@tauri-apps/plugin-fs');
+        const dir = docsDir(workspacePath, boardId);
+        const dirExists = await exists(dir);
+        if (!dirExists) return [];
+
+        return await listDirRecursive(dir, dir);
+    } catch (e) {
+        console.warn('[board-docs] Failed to list doc files:', e);
+        return [];
+    }
+}
+
+async function listDirRecursive(
+    absoluteDir: string,
+    rootDir: string,
+): Promise<DocFileEntry[]> {
+    const { readDir } = await import('@tauri-apps/plugin-fs');
+    const entries = await readDir(absoluteDir);
+    const results: DocFileEntry[] = [];
+
+    for (const entry of entries) {
+        // Skip hidden files
+        if (entry.name?.startsWith('.')) continue;
+
+        if (entry.isDirectory) {
+            const children = await listDirRecursive(
+                `${absoluteDir}/${entry.name}`,
+                rootDir,
+            );
+            // Only include directories that have .md files inside
+            if (children.length > 0) {
+                results.push({
+                    name: entry.name!,
+                    relativePath: absoluteDir === rootDir
+                        ? entry.name!
+                        : `${absoluteDir.replace(rootDir + '/', '')}/${entry.name!}`,
+                    fullPath: `${absoluteDir}/${entry.name!}`,
+                    isDir: true,
+                    children,
+                });
+            }
+        } else if (entry.name?.endsWith('.md')) {
+            const relative = absoluteDir === rootDir
+                ? entry.name
+                : `${absoluteDir.replace(rootDir + '/', '')}/${entry.name}`;
+            results.push({
+                name: entry.name,
+                relativePath: relative,
+                fullPath: `${absoluteDir}/${entry.name}`,
+                isDir: false,
+                children: [],
+            });
+        }
+    }
+
+    // Sort: directories first, then alphabetical
+    results.sort((a, b) => {
+        if (a.isDir && !b.isDir) return -1;
+        if (!a.isDir && b.isDir) return 1;
+        return a.name.localeCompare(b.name);
+    });
+
+    return results;
+}
+
+/**
+ * Read the content of a markdown doc file.
+ * Returns null if the file doesn't exist or can't be read.
+ */
+export async function readDocFile(
+    workspacePath: string,
+    boardId: string,
+    relativePath: string,
+): Promise<string | null> {
+    try {
+        const { readTextFile } = await import('@tauri-apps/plugin-fs');
+        const fullPath = `${docsDir(workspacePath, boardId)}/${relativePath}`;
+        return await readTextFile(fullPath);
+    } catch (e) {
+        console.warn(`[board-docs] Failed to read file ${relativePath}:`, e);
+        return null;
+    }
+}
+
+/**
+ * Create a new markdown file in the board's docs directory.
+ * Creates parent directories if they don't exist.
+ * Returns the relative path of the created file, or null on failure.
+ */
+export async function createDocFile(
+    workspacePath: string,
+    boardId: string,
+    fileName: string,
+    content = '',
+): Promise<string | null> {
+    try {
+        const { mkdir, exists, writeTextFile } = await import('@tauri-apps/plugin-fs');
+        const dir = docsDir(workspacePath, boardId);
+
+        // Ensure docs directory exists
+        const dirExists = await exists(dir);
+        if (!dirExists) {
+            await mkdir(dir, { recursive: true });
+        }
+
+        const fullPath = `${dir}/${fileName}`;
+
+        // Ensure parent subdirectory exists if fileName contains slashes
+        if (fileName.includes('/')) {
+            const parentDir = fullPath.substring(0, fullPath.lastIndexOf('/'));
+            const parentExists = await exists(parentDir);
+            if (!parentExists) {
+                await mkdir(parentDir, { recursive: true });
+            }
+        }
+
+        await writeTextFile(fullPath, content);
+        return fileName;
+    } catch (e) {
+        console.warn(`[board-docs] Failed to create file ${fileName}:`, e);
+        return null;
+    }
+}
+
+/**
+ * Write content to a markdown doc file.
+ * Creates parent directories if they don't exist.
+ * Returns true on success, false on failure.
+ */
+export async function writeDocFile(
+    workspacePath: string,
+    boardId: string,
+    relativePath: string,
+    content: string,
+): Promise<boolean> {
+    try {
+        const { mkdir, exists, writeTextFile } = await import('@tauri-apps/plugin-fs');
+        const fullPath = `${docsDir(workspacePath, boardId)}/${relativePath}`;
+
+        // Ensure parent directory exists
+        const parentDir = fullPath.substring(0, fullPath.lastIndexOf('/'));
+        const parentExists = await exists(parentDir);
+        if (!parentExists) {
+            await mkdir(parentDir, { recursive: true });
+        }
+
+        await writeTextFile(fullPath, content);
+        return true;
+    } catch (e) {
+        console.warn(`[board-docs] Failed to write file ${relativePath}:`, e);
+        return false;
+    }
+}
+
+/**
+ * Check if the docs directory exists for a board.
+ */
+export async function docsDirectoryExists(
+    workspacePath: string,
+    boardId: string,
+): Promise<boolean> {
+    try {
+        const { exists } = await import('@tauri-apps/plugin-fs');
+        return await exists(docsDir(workspacePath, boardId));
+    } catch {
+        return false;
+    }
+}

--- a/packages/worklog/src/routes/workspace/[board_id]/+page.svelte
+++ b/packages/worklog/src/routes/workspace/[board_id]/+page.svelte
@@ -4,6 +4,7 @@
     import TableView from "$lib/components/app/table/table-board.svelte";
     import GanttView from "$lib/components/app/gantt/gantt-board.svelte";
     import CalendarView from "$lib/components/app/calendar/calendar-board.svelte";
+    import BoardDocs from "$lib/components/app/board/board-docs.svelte";
     import {
         Loading,
         InlineNotification,
@@ -15,6 +16,7 @@
         Table,
         ChartBarFloating,
         Calendar,
+        Document,
         WarningHex,
         ArrowLeft,
         Search,
@@ -66,10 +68,11 @@
     let tabBtn1 = $state<HTMLButtonElement | null>(null);
     let tabBtn2 = $state<HTMLButtonElement | null>(null);
     let tabBtn3 = $state<HTMLButtonElement | null>(null);
+    let tabBtn4 = $state<HTMLButtonElement | null>(null);
     let indicatorEl = $state<HTMLElement | null>(null);
 
     $effect(() => {
-        const btns = [tabBtn0, tabBtn1, tabBtn2, tabBtn3];
+        const btns = [tabBtn0, tabBtn1, tabBtn2, tabBtn3, tabBtn4];
         const btn = btns[selectedTab];
         const el = indicatorEl;
         if (!btn || !el) return;
@@ -244,6 +247,17 @@
                         <Calendar size={16} />
                         <span>{m.board_tab_calendar()}</span>
                     </button>
+                    <button
+                        bind:this={tabBtn4}
+                        role="tab"
+                        aria-selected={selectedTab === 4}
+                        class="view-tab"
+                        class:view-tab--active={selectedTab === 4}
+                        onclick={() => (selectedTab = 4)}
+                    >
+                        <Document size={16} />
+                        <span>Docs</span>
+                    </button>
                     <span
                         bind:this={indicatorEl}
                         class="tab-indicator"
@@ -298,6 +312,11 @@
                     <GanttView {searchQuery} />
                 {:else if selectedTab === 3}
                     <CalendarView {searchQuery} />
+                {:else if selectedTab === 4 && board}
+                    <BoardDocs
+                        workspacePath={shell.workspace.path ?? ""}
+                        boardId={board.id}
+                    />
                 {/if}
             </div>
         </section>


### PR DESCRIPTION
- Introduced a new "Docs" tab in the board detail view, allowing users to browse, create, and edit markdown files.
- Implemented file tree structure to display markdown files stored in the filesystem.
- Added functionality to create, read, and write markdown files using Tauri's filesystem plugin.
- Created a new component `board-docs.svelte` to handle the file tree and markdown editor.
- Updated `+page.svelte` to integrate the new Docs tab and its functionality.
- Added a new hook `board-docs.svelte.ts` for managing markdown file operations.
- Documented the implementation plan and storage strategy for markdown files.